### PR TITLE
make "up" escape sequence work right

### DIFF
--- a/behave/formatter/ansi_escapes.py
+++ b/behave/formatter/ansi_escapes.py
@@ -27,7 +27,7 @@ aliases = {
 
 escapes = {
     'reset':        u'\x1b[0m',
-    'up':           u'\x1b[#1A',
+    'up':           u'\x1b[1A',
 }
 
 if 'GHERKIN_COLORS' in os.environ:
@@ -42,4 +42,4 @@ for alias in aliases:
 
 
 def up(n):
-    return u"\x1b[#%dA" % n
+    return u"\x1b[%dA" % n


### PR DESCRIPTION
See [https://github.com/jeamland/behave/issues/38](issue 38) on main branch. Currently the "up" escape sequence doesn't work right on some terminals (e.g. Gnome Terminal, the standard on Ubuntu; also xterm, a long-time fave). It does work correctly on "screen" and rxvt.

This tiny change (removing a "#" in two places) makes the sequence work right, so the output is as pretty as it is supposed to be. It also seems to work fine on "screen" and rxvt. (I don't know what terminal the devs are using.)
