### PR TITLE
Snippets for non-english languages should not contain escaped letters. Printing well formed text instead.

### DIFF
--- a/behave/__main__.py
+++ b/behave/__main__.py
@@ -107,7 +107,7 @@ def main():
                 continue
             printed.add(step)
 
-            msg += "@" + step.step_type + "(" + repr(step.name) + ")\n"
+            msg += "@" + step.step_type + "(u'" + step.name + "')\n"
             msg += "def impl(context):\n"
             msg += "    assert False\n\n"
 


### PR DESCRIPTION
## In short

Original code produce following output for russian:

```
$ behave 
Функционал: Тест
  Сценарий: Тест
    Допустим нужно выводить таблицу 5 на 10 в html
...
You can implement step definitions for undefined steps with these snippets:                                                                                   
@given(u'\u043d\u0443\u0436\u043d\u043e \u0432\u044b\u0432\u043e\u0434\u0438\u0442\u044c \u0442\u0430\u0431\u043b\u0438\u0446\u0443 5 \u043d\u0430 10 \u0432 html')                                                                                                                                                         
def impl(context):                                                                                                                                            
    assert False                                                                                                                                              
```

As you can see: all russian letters was escaped by **repr** function

After the patch:

```
$ behave 
Функционал: Тест
  Сценарий: Тест
    Допустим нужно выводить таблицу 5 на 10 в html
...
You can implement step definitions for undefined steps with these snippets:                                                                                   
@given(u'нужно выводить таблицу 5 на 10 в html')                                                                                                              
def impl(context):                                                                                                                                            
    assert False                                                                                                                                              
```
## Possible Problems

If step.name isn't always have unicode type then UnicodeDecodeError may occur

But as you can see it works well in my configuration
## Test environment

Ubuntu Linux, Utf-8 
