### PR TITLE
Allow using multiple formatters

### DIFF
--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -190,7 +190,7 @@ options = [
           help="""Display the summary at the end of the run.""")),
 
     (('-o', '--outfile'),
-     dict(metavar='FILE',
+     dict(action='append', metavar='FILE',
           help="Write to specified file instead of stdout.")),
 
     (('-q', '--quiet'),
@@ -357,6 +357,7 @@ class Configuration(object):
     def __init__(self):
         self.formatters = []
         self.reporters = []
+        self.outputs = []
         load_configuration(self.defaults)
         parser.set_defaults(**self.defaults)
 
@@ -366,10 +367,14 @@ class Configuration(object):
                 continue
             setattr(self, key, value)
 
-        if args.outfile and args.outfile != '-':
-            self.output = open(args.outfile, 'w')
+        if args.outfile is None:
+            self.outputs.append(sys.stdout)
         else:
-            self.output = sys.stdout
+            for outfile in args.outfile:
+                if outfile and outfile != '-':
+                    self.outputs.append(open(outfile, 'w'))
+                else:
+                    self.outputs.append(sys.stdout)
 
         if self.wip:
             # Only run scenarios tagged with "wip". Additionally: use the

--- a/behave/formatter/formatters.py
+++ b/behave/formatter/formatters.py
@@ -16,26 +16,30 @@ def list_formatters(stream):
         stream.write(u'%s: %s\n' % (name, formatters[name].description))
 
 
-def get_formatter(config, stream):
+def get_formatter(config, streams):
     # the stream may already handle encoding (py3k sys.stdout) - if it
     # doesn't (py2k sys.stdout) then make it do so.
     if sys.version_info[0] < 3:
         # py2 does, however, sometimes declare an encoding on sys.stdout,
         # even if it doesn't use it (or it might be explicitly None)
-        encoding = getattr(stream, 'encoding', None) or 'UTF-8'
-        stream = codecs.getwriter(encoding)(stream)
+        for stream in streams:
+            encoding = getattr(stream, 'encoding', None) or 'UTF-8'
+            stream = codecs.getwriter(encoding)(stream)
     elif not getattr(stream, 'encoding', None):
         # ok, so the stream doesn't have an encoding at all so add one
-        stream = codecs.getwriter('UTF-8')(stream)
+        for stream in streams:
+            stream = codecs.getwriter('UTF-8')(stream)
 
     # TODO complete this
-    formatter = None
-    for name in config.format:
-        if formatter is None:
-            formatter = formatters[name](stream, config)
+    formatter_list = []
+    for i in range(len(config.format)):
+        name = config.format[i]
+        if i < len(streams):
+            stream = streams[i]
         else:
-            formatter = formatters[name](formatter, config)
-    return formatter
+            stream = sys.stdout
+        formatter_list.append(formatters[name](stream, config))
+    return formatter_list
 
 # -----------------------------------------------------------------------------
 # REGISTER KNOWN FORMATTERS:

--- a/behave/model.py
+++ b/behave/model.py
@@ -213,7 +213,8 @@ class Feature(TagStatement, Replayable):
             run_feature = run_feature or runner.config.tags.check(tags)
 
         if run_feature or runner.config.show_skipped:
-            runner.formatter.feature(self)
+            for formatter in runner.formatters:
+                formatter.feature(self)
 
         # current tags as a set
         runner.context.tags = set(self.tags)
@@ -224,7 +225,8 @@ class Feature(TagStatement, Replayable):
             runner.run_hook('before_feature', runner.context, self)
 
         if self.background and (run_feature or runner.config.show_skipped):
-            runner.formatter.background(self.background)
+            for formatter in runner.formatters:
+                formatter.background(self.background)
 
         failed_count = 0
         for scenario in self:
@@ -243,9 +245,12 @@ class Feature(TagStatement, Replayable):
 
         runner.context._pop()
 
-        runner.formatter.eof()
+        for formatter in runner.formatters:
+            formatter.eof()
+
         if run_feature or runner.config.show_skipped:
-            runner.formatter.stream.write('\n')
+            for formatter in runner.formatters:
+                formatter.stream.write('\n')
 
         failed = (failed_count > 0)
         return failed
@@ -410,7 +415,8 @@ class Scenario(TagStatement, Replayable):
         run_steps = run_scenario and not runner.config.dry_run
 
         if run_scenario or runner.config.show_skipped:
-            runner.formatter.scenario(self)
+            for formatter in runner.formatters:
+                formatter.scenario(self)
 
         runner.context._push()
         runner.context.scenario = self
@@ -427,7 +433,8 @@ class Scenario(TagStatement, Replayable):
 
         if run_scenario or runner.config.show_skipped:
             for step in self:
-                runner.formatter.step(step)
+                for formatter in runner.formatters:
+                    formatter.step(step)
 
         for step in self:
             if run_steps:
@@ -734,16 +741,22 @@ class Step(BasicStatement, Replayable):
         if match is None:
             runner.undefined.append(self)
             if not quiet:
-                runner.formatter.match(NoMatch())
+                for formatter in runner.formatters:
+                    formatter.match(NoMatch())
+
             self.status = 'undefined'
             if not quiet:
-                runner.formatter.result(self)
+                for formatter in runner.formatters:
+                    formatter.result(self)
+
             return False
 
         keep_going = True
 
         if not quiet:
-            runner.formatter.match(match)
+            for formatter in runner.formatters:
+                formatter.match(match)
+
         runner.run_hook('before_step', runner.context, self)
         runner.start_capture()
 
@@ -791,7 +804,9 @@ class Step(BasicStatement, Replayable):
             keep_going = False
 
         if not quiet:
-            runner.formatter.result(self)
+            for formatter in runner.formatters:
+                formatter.result(self)
+
         runner.run_hook('after_step', runner.context, self)
 
         return keep_going

--- a/behave/runner.py
+++ b/behave/runner.py
@@ -504,7 +504,7 @@ class Runner(object):
         context = self.context = Context(self)
         # -- ENSURE: context.execute_steps() works in weird cases (hooks, ...)
         self.setup_capture()
-        stream = self.config.output
+        streams = self.config.outputs
         failed = False
         failed_count = 0
 
@@ -522,14 +522,18 @@ class Runner(object):
             self.features.append(feature)
             self.feature = feature
 
-            self.formatter = formatters.get_formatter(self.config, stream)
-            self.formatter.uri(filename)
+            self.formatters = formatters.get_formatter(self.config, streams)
+            for formatter in self.formatters:
+                formatter.uri(filename)
+
 
             failed = feature.run(self)
             if failed:
                 failed_count += 1
 
-            self.formatter.close()
+            for formatter in self.formatters:
+                formatter.close()
+
             for reporter in self.config.reporters:
                 reporter.feature(feature)
 


### PR DESCRIPTION
Formatters (and output files can now be chained):

```
behave -f plain -o plain.txt -f json -o result.json -f pretty
```

Empty stream assumes that sys.stdout will be used. Note, that -f option without a -o parameter should be specified last (not sure whether it is fixable - this seems natural to me)

Fixes #47

Sorry for spamming with PR, had to rebase onto master
