### PR TITLE
behave's exit code only depends on the last scenario of the last feature

### DIFF
--- a/behave/model.py
+++ b/behave/model.py
@@ -233,7 +233,7 @@ class Feature(TagStatement, Replayable):
             runner.formatter.background(self.background)
 
         for scenario in self:
-            failed = scenario.run(runner)
+            failed |= scenario.run(runner)
 
             # do we want to stop on the first failure?
             if failed and runner.config.stop:
@@ -582,9 +582,9 @@ class ScenarioOutline(Scenario):
 
         for sub in self.scenarios:
             runner.context._set_root_attribute('active_outline', sub._row)
-            failed = sub.run(runner)
+            failed |= sub.run(runner)
             if failed and runner.config.stop:
-                return False
+                break
         runner.context._set_root_attribute('active_outline', None)
 
         return failed

--- a/behave/runner.py
+++ b/behave/runner.py
@@ -458,7 +458,7 @@ class Runner(object):
             self.formatter = formatters.get_formatter(self.config, stream)
             self.formatter.uri(filename)
 
-            failed = feature.run(self)
+            failed |= feature.run(self)
 
             self.formatter.close()
             stream.write('\n')


### PR DESCRIPTION
It looks like behave always exits with 0 if the last scenario of the last feature did not fail (when not used with --wip or --stop).

This small patch makes it so that behave exits with 1 if any step of any scenario of any feature fails.

(BTW: thanks for the tool! We are using it successfully to add tests to a large Python code base.)
