### PR TITLE
Normalize paths provided at the command line.

### DIFF
--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -362,6 +362,8 @@ class Configuration(object):
                 continue
             setattr(self, key, value)
 
+        self.paths = [os.path.normpath(path) for path in self.paths]
+
         if args.outfile and args.outfile != '-':
             self.output = open(args.outfile, 'w')
         else:


### PR DESCRIPTION
This ensures that trailing slashes are removed if they exist.
This resolves a bug further down in the junit reporter where it would
chop off the first character of test case names if there was a trailing
slash in the path.
