### PR TITLE
Do not print a blank line when the feature is skipped

### DIFF
--- a/behave/model.py
+++ b/behave/model.py
@@ -252,9 +252,7 @@ class Feature(TagStatement, Replayable):
 
         runner.formatter.eof()
         if run_feature or runner.config.show_skipped:
-            # -- DISABLED: Not needed, bad for ProgressFormatter.
-            # runner.formatter.stream.write('\n')
-            pass
+            runner.formatter.stream.write('\n')
 
         failed = (failed_count > 0)
         return failed

--- a/behave/runner.py
+++ b/behave/runner.py
@@ -527,7 +527,6 @@ class Runner(object):
                 failed_count += 1
 
             self.formatter.close()
-            stream.write('\n')
             for reporter in self.config.reporters:
                 reporter.feature(feature)
 


### PR DESCRIPTION
When you have 36 feature files, and you execute only 1 (with `--tags @this_feature` for example), there's 35 blank lines printed before the interesting stuff begins.

This patch will print the blank line only if the header line `Feature: ...` is printed.

I've checked that it is friendly with the progress formatters too.
