### PR TITLE
Advanced travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - 2.7
   - pypy
 
-install: pip install --use-mirrors -q mock nose PyHamcrest
+install: pip install --use-mirrors -q mock nose PyHamcrest .
 
 script:
  - nosetests


### PR DESCRIPTION
This PR improves Travis tests - also installs current behave and runs self-test suite. For instance, this shows that behave will fail in python 2.5. Sample run - https://travis-ci.org/roignac/behave/builds/5144442
