### PR TITLE
Remove python 2.5 support as issue tests don't pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - 2.5
   - 2.6
   - 2.7
   - pypy


### PR DESCRIPTION
Inner test suite steps use py2.6 features and cannot be easily converted to py2.5. I propose to remove py2.5 support.
