### PR TITLE
Issue #135: avoid leaking globals between step modules

### DIFF
--- a/behave/runner.py
+++ b/behave/runner.py
@@ -442,9 +442,10 @@ class Runner(object):
             for name in os.listdir(path):
                 if name.endswith('.py'):
                     # -- LOAD STEP DEFINITION:
+                    # Copy the globals to avoid leaking vars to other steps.
                     # Reset to default matcher after each step-definition.
                     # A step-definition may change the matcher 0..N times.
-                    exec_file(os.path.join(path, name), step_globals)
+                    exec_file(os.path.join(path, name), step_globals.copy())
                     matchers.current_matcher = default_matcher
 
         # -- CLEANUP: Clean up the path.


### PR DESCRIPTION
Fix the issue described in #135 about variables and imports which are available for all the step definitions.
