### PR TITLE
Sort files, features and scenarios before running

### DIFF
--- a/behave/model.py
+++ b/behave/model.py
@@ -208,7 +208,7 @@ class Feature(TagStatement, Replayable):
         # run this feature if the tags say to for itself or any one of its
         # scenarios
         run_feature = runner.config.tags.check(self.tags)
-        for scenario in self:
+        for scenario in sorted(self):
             tags = scenario.tags
             run_feature = run_feature or runner.config.tags.check(tags)
 

--- a/behave/runner.py
+++ b/behave/runner.py
@@ -480,7 +480,8 @@ class Runner(object):
         for path in self.config.paths:
             if os.path.isdir(path):
                 for dirpath, dirnames, filenames in os.walk(path):
-                    for filename in filenames:
+                    dirnames.sort()
+                    for filename in sorted(filenames):
                         if filename.endswith('.feature'):
                             files.append(os.path.join(dirpath, filename))
             elif path.startswith('@'):
@@ -490,7 +491,7 @@ class Runner(object):
                 files.append(path)
             else:
                 raise Exception("Can't find path: " + path)
-        return files
+        return sorted(files)
 
     def run(self):
         with self.path_manager:

--- a/issue.features/issue0099.feature
+++ b/issue.features/issue0099.feature
@@ -121,10 +121,10 @@ Feature: Issue #99: Layout variation "a directory containing your feature files"
         """
     And the command output should contain:
         """
-        Feature: Charly
-          Scenario:
-            When a step passes ... passed
         Feature: Alice
           Scenario:
             Given a step passes ... passed
+        Feature: Charly
+          Scenario:
+            When a step passes ... passed
         """


### PR DESCRIPTION
Always sort feature files and scenarios to ensure that they are not run in random order. Also includes fix from issue #103
