### PR TITLE
Don't check for full package in issue 112

### DIFF
--- a/issue.features/issue0112.feature
+++ b/issue.features/issue0112.feature
@@ -59,6 +59,6 @@ Feature: Issue #112: Improvement to AmbiguousStep error
     Then it should fail
     And the command output should contain:
         """
-        behave.step_registry.AmbiguousStep: "I buy {number:n} {items:w}" has already been defined in
+        AmbiguousStep: "I buy {number:n} {items:w}" has already been defined in
           existing step: "I buy {amount} {product}" (features/steps/bad_steps.py:4)
         """


### PR DESCRIPTION
Pypi doesn't output package for AmbigousStep, which breaks [pypy self-check suite on travis](https://s3.amazonaws.com/archive.travis-ci.org/jobs/5779205/log.txt):

```
Expected: a string containing u'behave.step_registry.AmbiguousStep:[snip]
     but: was '[snip]\nAmbiguousStep: "I buy {number:n} {items:w}" has already been defined in\nexisting step: "I buy {amount} {product}" (features/steps/bad_steps.py:4)'

```
