### PR TITLE
Updated fix for issue #143 - log capture started too late

### DIFF
--- a/behave/runner.py
+++ b/behave/runner.py
@@ -493,6 +493,8 @@ class Runner(object):
         return files
 
     def run(self):
+        self.context = Context(self)
+        self.setup_capture()
         with self.path_manager:
             self.setup_paths()
             return self.run_with_paths()
@@ -501,9 +503,8 @@ class Runner(object):
         self.load_hooks()
         self.load_step_definitions()
 
-        context = self.context = Context(self)
+        context = self.context
         # -- ENSURE: context.execute_steps() works in weird cases (hooks, ...)
-        self.setup_capture()
         stream = self.config.output
         failed = False
         failed_count = 0

--- a/issue.features/issue0143.feature
+++ b/issue.features/issue0143.feature
@@ -1,0 +1,31 @@
+@issue
+Feature: Issue #143: Logging starts with a StreamHandler way too early
+
+    | This verifies that some imported library or other item has not made a
+    | call to logging too soon, which would add a StreamHandler.
+
+  Scenario:
+    Given a file named "features/steps/steps.py" with:
+        """
+        import logging
+        from behave import given, when, then, step
+
+        @step('I log debug {num} times')
+        def log_output(context, num):
+            for i in xrange(int(num)):
+                logging.debug('Some debug logging')
+        """
+    And a file named "features/issue0143_example.feature" with:
+        """
+        Feature: Logging should not be output unless there is a failure
+
+            Scenario: A passing test
+                Given I log debug 100 times
+        """
+    When I run "behave -f plain features/issue0143_example.feature"
+    Then it should pass
+    And the command output should not contain:
+        """
+        DEBUG:root:Some debug logging
+        """
+

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -451,6 +451,7 @@ class TestRunner(object):
 
     def test_run_returns_true_if_everything_passed(self):
         r = runner.Runner(Mock())
+        r.setup_capture = Mock()
         r.setup_paths = Mock()
         r.run_with_paths = Mock()
         r.run_with_paths.return_value = True
@@ -458,6 +459,7 @@ class TestRunner(object):
 
     def test_run_returns_false_if_anything_failed(self):
         r = runner.Runner(Mock())
+        r.setup_capture = Mock()
         r.setup_paths = Mock()
         r.run_with_paths = Mock()
         r.run_with_paths.return_value = False


### PR DESCRIPTION
This commit ensures that setup_capture() is called before the parse library
has a chance to log anything. The unit tests have been updated to mock setup_capture, since it was relocated to the main run() method.
