### PR TITLE
Features' tags are inherited by scenarios.

### DIFF
--- a/behave/model.py
+++ b/behave/model.py
@@ -208,9 +208,12 @@ class Feature(TagStatement, Replayable):
         # run this feature if the tags say to for itself or any one of its
         # scenarios
         run_feature = runner.config.tags.check(self.tags)
-        for scenario in self:
-            tags = scenario.tags
-            run_feature = run_feature or runner.config.tags.check(tags)
+        if not run_feature:
+            for scenario in self:
+                tags = scenario.tags
+                run_feature = runner.config.tags.check(tags + self.tags)
+                if run_feature:
+                    break
 
         if run_feature or runner.config.show_skipped:
             runner.formatter.feature(self)


### PR DESCRIPTION
This makes it more easy to exclude completely features based on tags. BTW,
this is follows Cucumber behavior as described here:

https://github.com/cucumber/cucumber/wiki/Tags
