### PR TITLE
FIX: encode the output for junit reporter.

### DIFF
--- a/behave/reporter/junit.py
+++ b/behave/reporter/junit.py
@@ -31,7 +31,8 @@ if hasattr(ElementTree, '_serialize'):
     def _serialize_xml(write, elem, encoding, qnames, namespaces,
                        orig=ElementTree._serialize_xml):
         if elem.tag == '![CDATA[':
-            write("\n<%s%s]]>\n" % (elem.tag, elem.text))
+            text = ("\n<%s%s]]>\n" % (elem.tag, elem.text)).encode(encoding)
+            write(text)
             return
         return orig(write, elem, encoding, qnames, namespaces)
 


### PR DESCRIPTION
This patch fixes the test suite on Python 2.7 and PyPy.
