### PR TITLE
FIX issue #114: do not print a blank line when the feature is skipped

### DIFF
--- a/behave/formatter/progress.py
+++ b/behave/formatter/progress.py
@@ -80,11 +80,8 @@ class ProgressFormatterBase(Formatter):
         Called at end of a feature.
         It would be better to have a hook that is called after all features.
         """
-        feature = self.current_feature
         self.report_scenario_progress()
-        if ( self.config.show_skipped or
-            (feature and feature.status != "skipped")):
-            self.stream.write('\n')
+        self.stream.write('\n')
         self.report_failures()
         self.stream.flush()
         self.reset()

--- a/behave/model.py
+++ b/behave/model.py
@@ -313,14 +313,9 @@ class Feature(TagStatement, Replayable):
 
         runner.context._pop()
 
-        for formatter in runner.formatters:
-            formatter.eof()
-
-        # -- FIX issue #153:
-        # if run_feature or runner.config.show_skipped:
-        #     for formatter in runner.formatters:
-        #         # formatter.stream.write('\n')
-        #         pass
+        if run_feature or runner.config.show_skipped:
+            for formatter in runner.formatters:
+                formatter.eof()
 
         failed = (failed_count > 0)
         return failed

--- a/issue.features/issue0114.feature
+++ b/issue.features/issue0114.feature
@@ -86,3 +86,33 @@ Feature: Issue #114: Avoid unnecessary blank lines w/ --no-skipped option
         """
         features/e2.feature  .
         """
+
+  Scenario: Run Features with tag, --no-skipped and plain formatter (CASE 3)
+    When I run "behave -f plain --tags=@example --no-skipped"
+    Then it should pass with:
+        """
+        2 features passed, 0 failed, 1 skipped
+        2 scenarios passed, 0 failed, 1 skipped
+        2 steps passed, 0 failed, 1 skipped, 0 undefined
+        """
+    And the command output should contain exactly:
+        """
+        Feature: E1
+
+          Scenario: S1.1
+            Given a step passes ... passed
+
+        Feature: E3
+
+        """
+    But the command output should not contain exactly:
+        """
+        Feature: E1
+
+          Scenario: S1.1
+            Given a step passes ... passed
+
+
+        Feature: E3
+
+        """


### PR DESCRIPTION
This fixes a regression due to fix for issue #153.
The original bug was reported and fixed with #114.

And tests added too.
