### PR TITLE
Support subfolders for step definition files

### DIFF
--- a/behave/runner.py
+++ b/behave/runner.py
@@ -451,13 +451,14 @@ class Runner(object):
             for path in paths:
                 for dirpath, dirnames, filenames in os.walk(path):
                     for name in sorted(filenames):
-                        # -- LOAD STEP DEFINITION:
-                        # Reset to default matcher after each step-definition.
-                        # A step-definition may change the matcher 0..N times.
-                        # ENSURE: Each step definition has clean globals.
-                        step_module_globals = step_globals.copy()
-                        exec_file(os.path.join(dirpath, name), step_module_globals)
-                        matchers.current_matcher = default_matcher
+                        if name.endswith('.py'):
+                            # -- LOAD STEP DEFINITION:
+                            # Reset to default matcher after each step-definition.
+                            # A step-definition may change the matcher 0..N times.
+                            # ENSURE: Each step definition has clean globals.
+                            step_module_globals = step_globals.copy()
+                            exec_file(os.path.join(dirpath, name), step_module_globals)
+                            matchers.current_matcher = default_matcher
 
     def run_hook(self, name, context, *args):
         if not self.config.dry_run and (name in self.hooks):

--- a/behave/runner.py
+++ b/behave/runner.py
@@ -449,14 +449,14 @@ class Runner(object):
         with PathManager(paths):
             default_matcher = matchers.current_matcher
             for path in paths:
-                for name in sorted(os.listdir(path)):
-                    if name.endswith('.py'):
+                for dirpath, dirnames, filenames in os.walk(path):
+                    for name in sorted(filenames):
                         # -- LOAD STEP DEFINITION:
                         # Reset to default matcher after each step-definition.
                         # A step-definition may change the matcher 0..N times.
                         # ENSURE: Each step definition has clean globals.
                         step_module_globals = step_globals.copy()
-                        exec_file(os.path.join(path, name), step_module_globals)
+                        exec_file(os.path.join(dirpath, name), step_module_globals)
                         matchers.current_matcher = default_matcher
 
     def run_hook(self, name, context, *args):

--- a/features/directory_layout.advanced.feature
+++ b/features/directory_layout.advanced.feature
@@ -34,6 +34,30 @@ Feature: Advanced, more complex directory layout (Variant 2)
             def step_fails(context, word):
                 assert False, "XFAIL-STEP"
             """
+        And a file named "features/steps/subfolder_1/steps.py" with:
+            """
+            from behave import step
+
+            @step('{word:w} step from subfolder 1 passes')
+            def step_from_subfolder_also_passes(context, word):
+                pass
+
+            @step('{word:w} step from subfolder 1 fails')
+            def step_from_subfolder_fails(context, word):
+                assert False, "XFAIL-STEP"
+            """
+        And a file named "features/steps/subfolder_2/steps.py" with:
+            """
+            from behave import step
+
+            @step('{word:w} step from subfolder 2 passes')
+            def step_from_subfolder_also_passes(context, word):
+                pass
+
+            @step('{word:w} step from subfolder 2 fails')
+            def step_from_subfolder_fails(context, word):
+                assert False, "XFAIL-STEP"
+            """
         And a file named "features/steps/environment_steps.py" with:
             """
             from behave import step
@@ -72,15 +96,24 @@ Feature: Advanced, more complex directory layout (Variant 2)
                   Given another step passes
                   Then a step passes
             """
+        And a file named "features/group3/dan.feature" with:
+            """
+            Feature: Dan
+                Scenario: D1
+                  Given a step from subfolder 1 passes
+                    And another step from subfolder 1 passes
+                    And some step from subfolder 2 passes
+                  Then any step from subfolder 2 passes
+            """
 
 
     Scenario: Run behave with feature directory
         When I run "behave -f progress features/"
         Then it should pass with:
             """
-            3 features passed, 0 failed, 0 skipped
-            4 scenarios passed, 0 failed, 0 skipped
-            8 steps passed, 0 failed, 0 skipped, 0 undefined
+            4 features passed, 0 failed, 0 skipped
+            5 scenarios passed, 0 failed, 0 skipped
+            12 steps passed, 0 failed, 0 skipped, 0 undefined
             """
 
     Scenario: Run behave with feature subdirectory (CASE 1)
@@ -144,4 +177,13 @@ Feature: Advanced, more complex directory layout (Variant 2)
             2 features passed, 0 failed, 0 skipped
             3 scenarios passed, 0 failed, 0 skipped
             6 steps passed, 0 failed, 0 skipped, 0 undefined
+            """
+
+    Scenario: Run behave with steps stored in subfolders
+        When I run "behave -f progress features/group3/dan.feature"
+        Then it should pass with:
+            """
+            1 feature passed, 0 failed, 0 skipped
+            1 scenario passed, 0 failed, 0 skipped
+            4 steps passed, 0 failed, 0 skipped, 0 undefined
             """


### PR DESCRIPTION
This change will allow to place step definitions in subfolders:

```
features/
+-- *.feature
+-- steps
|     +-- subfolder_1/
|     |    +-- *.py
|     +-- subfolder_2/
|     |    +-- *.py
```

etc.
Fixes #169
