### PR TITLE
JUnit report should contain subfolder name

### DIFF
--- a/behave/reporter/junit.py
+++ b/behave/reporter/junit.py
@@ -80,7 +80,7 @@ class JUnitReporter(Reporter):
         if not filename:
             # TODO: Directory path (subdirs) should be taken into account.
             # filename = os.path.split(feature.filename)[1]
-            filename = os.path.basename(feature.filename)
+            filename = feature.location.abspath()[len(self.config.base_dir) + 1:]
         filename = filename.rsplit('.', 1)[0]
         filename = filename.replace('\\', '/').replace('/', '.')
         return filename

--- a/behave/runner.py
+++ b/behave/runner.py
@@ -382,6 +382,7 @@ class Runner(object):
             base_dir = os.path.abspath('features')
 
         # Get the root. This is not guaranteed to be '/' because Windows.
+        self.config.base_dir = base_dir
         root_dir = path_getrootdir(base_dir)
         new_base_dir = base_dir
 

--- a/issue.features/issue0172.feature
+++ b/issue.features/issue0172.feature
@@ -48,4 +48,4 @@ Feature: Issue #172 Junit report file name populated incorrectly when running ag
       2 features passed, 0 failed, 0 skipped
       """
     And a file named "test_results/TESTS-feature_in_root_folder.xml" exists
-    And a file named "test_results/TESTS-feature_in_subfolder.xml" exists
+    And a file named "test_results/TESTS-subfolder.feature_in_subfolder.xml" exists


### PR DESCRIPTION
This reduces ambiguity of JUnit reports for feature files with the same name but placed in different folders

This is related to #172
