### PR TITLE
Issue #177, section d: logging configuration more friendly out of the box

### DIFF
--- a/behave/log_capture.py
+++ b/behave/log_capture.py
@@ -83,7 +83,7 @@ class LoggingCapture(BufferingHandler):
                 raise ConfigError('Invalid log level: "%s"' %
                                   config.logging_level)
         else:
-            self.level = logging.NOTSET
+            self.level = logging.INFO
 
         # construct my filter
         if config.logging_filter:


### PR DESCRIPTION
`NOTSET` strikes me as punishing the user for not setting a logging level. `INFO` is probably a more sensible default.
