### PR TITLE
Add coveralls support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,8 +10,9 @@
 [run]
 append  = .coverage
 include = behave*
+omit = nose
 branch  = True
-parallel = True
+#parallel = True
 
 [report]
 # Regexes for lines to exclude from consideration
@@ -39,4 +40,3 @@ directory = build/coverage.html
 
 [xml]
 outfile = build/coverage.xml
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,14 @@ python:
   - pypy
 
 install:
-  - pip install --use-mirrors -q mock nose PyHamcrest
+  - pip install --use-mirrors -q mock nose PyHamcrest python-coveralls
   - python setup.py -q install
 script:
   - python --version
-  - nosetests
-  - behave -f progress --junit --tags=~@xfail features/
-  - behave -f progress --junit --tags=~@xfail tools/test-features/
-  - behave -f progress --junit --tags=~@xfail issue.features/
+  - nosetests --with-coverage
+  - COVERAGE_FILE=.coverage.features coverage run bin/behave -f progress --junit --tags=~@xfail features/
+  - COVERAGE_FILE=.coverage.tools coverage run bin/behave -f progress --junit --tags=~@xfail tools/test-features/
+  - COVERAGE_FILE=.coverage.issues coverage run bin/behave -f progress --junit --tags=~@xfail issue.features/
+after_success:
+  - coverage combine
+  - coveralls


### PR DESCRIPTION
Use http://coveralls.io to measure code coverage. This gives several nice features:
- View and compare coverage for existing code with handy code browser. This helps us to identify untested code
- Check PRs code coverage. 'Changed' tab on coveralls will show if all the added code is being covered with tests. Coverall comments the PR with coverage report

Sample links:
- [Coverage progress for my behave repo](https://coveralls.io/r/roignac/behave)
- [Coverage report for PR](https://coveralls.io/builds/154887) and [sample comment](https://github.com/roignac/behave/pull/3#issuecomment-22456979)

Actions required:
- Register the repo at http://coveralls.io
- Merge the PR
- Put a badge in README.md

Note, that this change also does the following:
- Disables parallel nosetest - this confuses coveralls and doesn't really speed up tests
- Uses a nasty coverage-enabled run of self-test features in .travis.yml - this should be replaced with a nice macro, but I'm not sure how this is supposed to be implemented

It also shows minimal coverage for 'lazy-loaded' formatters - due to `load_module` usage coverage is minimal for some of them
