### PR TITLE
ScenarioOutline.run does not return correct value on failure

### DIFF
--- a/behave/model.py
+++ b/behave/model.py
@@ -864,15 +864,17 @@ class ScenarioOutline(Scenario):
 
     def run(self, runner):
         failed = False
+        failed_count = 0
 
         for sub in self.scenarios:
             runner.context._set_root_attribute('active_outline', sub._row)
             failed = sub.run(runner)
             if failed and runner.config.stop:
-                return False
+                return failed
+            if failed: failed_count += 1
         runner.context._set_root_attribute('active_outline', None)
 
-        return failed
+        return failed_count > 0
 
 
 class Examples(BasicStatement, Replayable):


### PR DESCRIPTION
ScenarioOutline returns  that it encountered a failure only if the last scenario failed. 
