### PR TITLE
fix: reporters: junit: match actual ElementTree._serialize_xml()

### DIFF
--- a/behave/reporter/junit.py
+++ b/behave/reporter/junit.py
@@ -42,7 +42,8 @@ if hasattr(ElementTree, '_serialize'):
                         short_empty_elements=None,
                         orig=ElementTree._serialize_xml):
         if elem.tag == '![CDATA[':
-            write("\n<%s%s]]>\n" % (elem.tag, elem.text.encode("UTF-8")))
+            write("\n<{tag}{text}]]>\n".format(
+                tag=elem.tag, text=elem.text))
             return
         if short_empty_elements:
             # python >=3.3


### PR DESCRIPTION
it looks like ElementTree's _serialize_xml method from std XML library have other arguments now

without this patch junit reporter don't works (i have tested on python 3.2 and 3.4)
