### PR TITLE
Correct bad variable name in tutorial.rst

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -322,7 +322,7 @@ clauses (with a Given step that puts some text into
  @then('the result page will include "{text}"')
  def step_impl(context, text):
     if text not in context.response:
-        fail('%r not in %r' % (message, context.response))
+        fail('%r not in %r' % (text, context.response))
 
 There are several parsers available in *behave* (by default):
 


### PR DESCRIPTION
Hi,
I spotted an error in tutorial.rst and changed variable name.
