### PR TITLE
switchable alternate step implementations

### DIFF
--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -240,6 +240,19 @@ options = [
      dict(action='append', dest='outfiles', metavar='FILE',
           help="Write to specified file instead of stdout.")),
 
+    (('--steps-prefix',),
+     dict(help="""Prepend the given prefix to the name of the steps directory
+                  and environment.py. Example: --steps-prefix=other_ will
+                  look for steps in the other_steps directory for each feature,
+                  and instead of environment.py, other_environment.py will be
+                  used.""",
+          config_help="""Prepend the given prefix to the name of the steps
+                         directory and environment.py. Example:
+                         ``steps-prefix = other_`` will look for steps in the
+                         other_steps directory for each feature, and instead of
+                         environment.py, other_environment.py will be
+                         used.""")),
+
     ((),  # -- CONFIGFILE only
      dict(action='append', dest='paths',
           help="Specify default feature paths, used when none are provided.")),
@@ -445,6 +458,9 @@ class Configuration(object):
         logging_level=logging.INFO,
         summary=True,
         junit=False,
+        steps_prefix='',
+        steps_dir='steps',
+        env_py='environment.py',
         # -- SPECIAL:
         default_format="pretty",   # -- Used when no formatters are configured.
         scenario_outline_annotation_schema=u"{name} -- @{row.id} {examples.name}"
@@ -545,6 +561,9 @@ class Configuration(object):
         unknown_formats = self.collect_unknown_formats()
         if unknown_formats:
             parser.error("format=%s is unknown" % ", ".join(unknown_formats))
+
+        self.steps_dir = self.steps_prefix + 'steps'
+        self.env_py = self.steps_prefix + 'environment.py'
 
         self.setup_model()
 

--- a/behave/runner.py
+++ b/behave/runner.py
@@ -567,9 +567,9 @@ class Runner(ModelRunner):
             if self.config.verbose:
                 print 'Trying base directory:', new_base_dir
 
-            if os.path.isdir(os.path.join(new_base_dir, 'steps')):
+            if os.path.isdir(os.path.join(new_base_dir, self.config.steps_dir)):
                 break
-            if os.path.isfile(os.path.join(new_base_dir, 'environment.py')):
+            if os.path.isfile(os.path.join(new_base_dir, self.config.env_py)):
                 break
             if new_base_dir == root_dir:
                 break
@@ -579,12 +579,17 @@ class Runner(ModelRunner):
         if new_base_dir == root_dir:
             if self.config.verbose:
                 if not self.config.paths:
-                    print 'ERROR: Could not find "steps" directory. Please '\
-                        'specify where to find your features.'
+                    print 'ERROR: Could not find "%s" directory. Please '\
+                        'specify where to find your features.' \
+                            % self.config.steps_dir
                 else:
-                    print 'ERROR: Could not find "steps" directory in your '\
-                        'specified path "%s"' % base_dir
-            raise ConfigError('No steps directory in "%s"' % base_dir)
+                    print 'ERROR: Could not find "%s" directory in your '\
+                        'specified path "%s"' \
+                            % (self.config.steps_dir, base_dir)
+
+            message = 'No %s directory in "%s"' \
+                          % (self.config.steps_dir, base_dir)
+            raise ConfigError(message)
 
         base_dir = new_base_dir
         self.config.base_dir = base_dir
@@ -617,7 +622,8 @@ class Runner(ModelRunner):
         """
         context.config.setup_logging()
 
-    def load_hooks(self, filename='environment.py'):
+    def load_hooks(self, filename=''):
+        filename = filename or self.config.env_py
         hooks_path = os.path.join(self.base_dir, filename)
         if os.path.exists(hooks_path):
             exec_file(hooks_path, self.hooks)
@@ -634,7 +640,7 @@ class Runner(ModelRunner):
 
         # -- Allow steps to import other stuff from the steps dir
         # NOTE: Default matcher can be overridden in "environment.py" hook.
-        steps_dir = os.path.join(self.base_dir, 'steps')
+        steps_dir = os.path.join(self.base_dir, self.config.steps_dir)
         paths = [steps_dir] + list(extra_step_paths)
         with PathManager(paths):
             default_matcher = matchers.current_matcher

--- a/features/step.alternate_step_implementations.feature
+++ b/features/step.alternate_step_implementations.feature
@@ -1,0 +1,46 @@
+Feature: Alternate step implementations
+
+  As I tester and test writer
+  I want to run the same feature with different step implementations in different environments
+  So I can run quick checks in a development environment and detailed checks in a testlab.
+
+    | Example directory layout:
+    |
+    |   .../features/
+    |       +-- example.feature
+    |       +-- steps/
+    |       |   +-- example.py
+    |       +-- environment.py
+    |       +-- testlab_steps/
+    |       |   +-- example.py
+    |       +-- testlab_environment.py
+
+  Scenario: Use steps from a directory other than "steps/"
+    Given a new working directory
+      And a file named "features/example_use_different_steps.feature" with:
+          """
+          Feature:
+            Scenario:
+              When I do something
+          """
+      And a file named "features/alternate_environment.py" with:
+          """
+          def before_feature(context, feature):
+              context.alternate_environment_is_in_use = True
+          """
+      And a file named "features/alternate_steps/example_steps.py" with:
+          """
+          from behave import step
+
+          @step('I do something')
+          def step_do_something(context):
+              assert context.alternate_environment_is_in_use, \
+                     "Expected alternate_environment.py to be used"
+          """
+     When I run "behave -f plain --steps-prefix alternate_ features/example_use_different_steps.feature"
+     Then it should pass with:
+          """
+          1 feature passed, 0 failed, 0 skipped
+          1 scenario passed, 0 failed, 0 skipped
+          1 step passed, 0 failed, 0 skipped, 0 undefined
+          """

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -1,6 +1,7 @@
 from __future__ import with_statement
 import os.path
 import tempfile
+import unittest
 
 from nose.tools import *
 from behave import configuration
@@ -40,4 +41,9 @@ class TestConfiguration(object):
         eq_(d['tags'], ['@foo,~@bar', '@zap'])
         eq_(d['stdout_capture'], False)
         ok_('bogus' not in d)
+
+    def test_settings_derived_from_steps_prefix(self):
+        config = configuration.Configuration(["--steps-prefix=prefixed_"])
+        eq_("prefixed_steps", config.steps_dir)
+        eq_("prefixed_environment.py", config.env_py)
 

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -404,6 +404,14 @@ Then a step passes
             self.context.execute_steps(doc)
 
 
+def create_mock_config():
+    config = Mock()
+    config.steps_dir = 'steps'
+    config.env_py = 'environment.py'
+
+    return config
+
+
 class TestRunner(object):
     def test_load_hooks_execfiles_hook_file(self):
         with patch('behave.runner.exec_file') as ef:
@@ -412,7 +420,7 @@ class TestRunner(object):
                 base_dir = 'fake/path'
                 hooks_path = os.path.join(base_dir, 'environment.py')
 
-                r = runner.Runner(None)
+                r = runner.Runner(create_mock_config())
                 r.base_dir = base_dir
                 r.load_hooks()
 
@@ -718,7 +726,7 @@ class FsMock(object):
 
 class TestFeatureDirectory(object):
     def test_default_path_no_steps(self):
-        config = Mock()
+        config = create_mock_config()
         config.paths = []
         config.verbose = True
         r = runner.Runner(config)
@@ -732,7 +740,7 @@ class TestFeatureDirectory(object):
         ok_(('isdir', os.path.join(fs.base, 'features', 'steps')) in fs.calls)
 
     def test_default_path_no_features(self):
-        config = Mock()
+        config = create_mock_config()
         config.paths = []
         config.verbose = True
         r = runner.Runner(config)
@@ -743,7 +751,7 @@ class TestFeatureDirectory(object):
                 assert_raises(ConfigError, r.setup_paths)
 
     def test_default_path(self):
-        config = Mock()
+        config = create_mock_config()
         config.paths = []
         config.verbose = True
         r = runner.Runner(config)
@@ -758,7 +766,7 @@ class TestFeatureDirectory(object):
         eq_(r.base_dir, os.path.abspath('features'))
 
     def test_supplied_feature_file(self):
-        config = Mock()
+        config = create_mock_config()
         config.paths = ['foo.feature']
         config.verbose = True
         r = runner.Runner(config)
@@ -776,7 +784,7 @@ class TestFeatureDirectory(object):
         eq_(r.base_dir, fs.base)
 
     def test_supplied_feature_file_no_steps(self):
-        config = Mock()
+        config = create_mock_config()
         config.paths = ['foo.feature']
         config.verbose = True
         r = runner.Runner(config)
@@ -789,7 +797,7 @@ class TestFeatureDirectory(object):
                     assert_raises(ConfigError, r.setup_paths)
 
     def test_supplied_feature_directory(self):
-        config = Mock()
+        config = create_mock_config()
         config.paths = ['spam']
         config.verbose = True
         r = runner.Runner(config)
@@ -806,7 +814,7 @@ class TestFeatureDirectory(object):
         eq_(r.base_dir, os.path.join(fs.base, 'spam'))
 
     def test_supplied_feature_directory_no_steps(self):
-        config = Mock()
+        config = create_mock_config()
         config.paths = ['spam']
         config.verbose = True
         r = runner.Runner(config)
@@ -820,7 +828,7 @@ class TestFeatureDirectory(object):
         ok_(('isdir', os.path.join(fs.base, 'spam', 'steps')) in fs.calls)
 
     def test_supplied_feature_directory_missing(self):
-        config = Mock()
+        config = create_mock_config()
         config.paths = ['spam']
         config.verbose = True
         r = runner.Runner(config)
@@ -834,7 +842,7 @@ class TestFeatureDirectory(object):
 
 class TestFeatureDirectoryLayout2(object):
     def test_default_path(self):
-        config = Mock()
+        config = create_mock_config()
         config.paths = []
         config.verbose = True
         r = runner.Runner(config)
@@ -854,7 +862,7 @@ class TestFeatureDirectoryLayout2(object):
         eq_(r.base_dir, os.path.abspath('features'))
 
     def test_supplied_root_directory(self):
-        config = Mock()
+        config = create_mock_config()
         config.paths = [ 'features' ]
         config.verbose = True
         r = runner.Runner(config)
@@ -875,7 +883,7 @@ class TestFeatureDirectoryLayout2(object):
         eq_(r.base_dir, os.path.join(fs.base, 'features'))
 
     def test_supplied_root_directory_no_steps(self):
-        config = Mock()
+        config = create_mock_config()
         config.paths = [ 'features' ]
         config.verbose = True
         r = runner.Runner(config)
@@ -896,7 +904,7 @@ class TestFeatureDirectoryLayout2(object):
 
 
     def test_supplied_feature_file(self):
-        config = Mock()
+        config = create_mock_config()
         config.paths = [ 'features/group1/foo.feature' ]
         config.verbose = True
         r = runner.Runner(config)
@@ -919,7 +927,7 @@ class TestFeatureDirectoryLayout2(object):
         eq_(r.base_dir, fs.join(fs.base, "features"))
 
     def test_supplied_feature_file_no_steps(self):
-        config = Mock()
+        config = create_mock_config()
         config.paths = [ 'features/group1/foo.feature' ]
         config.verbose = True
         r = runner.Runner(config)
@@ -936,7 +944,7 @@ class TestFeatureDirectoryLayout2(object):
                     assert_raises(ConfigError, r.setup_paths)
 
     def test_supplied_feature_directory(self):
-        config = Mock()
+        config = create_mock_config()
         config.paths = [ 'features/group1' ]
         config.verbose = True
         r = runner.Runner(config)
@@ -958,7 +966,7 @@ class TestFeatureDirectoryLayout2(object):
 
 
     def test_supplied_feature_directory_no_steps(self):
-        config = Mock()
+        config = create_mock_config()
         config.paths = [ 'features/group1' ]
         config.verbose = True
         r = runner.Runner(config)


### PR DESCRIPTION
When developing software that has to interact with many third party
components (e.g. control the behavior of various OS settings and
components, talk to external servers and databases and co.), it can come
handy to have two different sets of step automations for the same
feature files:
- one for a quick and reliable integration check that can
  be run frequently in a development environment (without the external
  resources that need to be allocated and released or might become
  flaky due to network latency or high load, etc.) which implements
  steps by inspecting what comes out from the software on its
  boundaries to external components,
- and another, that verifies the behavior of the full stack in a
  testing copy of production systems and networks using step
  implementations that inspect the effect of the software on the
  external components.

This patch provides a solution for such use cases by allowing the name
of the "steps/" directory and "environment.py" to be changed in a
consistent way with a single configuration option or command line
parameter as described in "step.alternate_step_implementations.feature".

(Travis-CI: https://travis-ci.org/attilammagyar/behave)
