### PR TITLE
expose tags in junit report

### DIFF
--- a/behave/reporter/junit.py
+++ b/behave/reporter/junit.py
@@ -174,9 +174,11 @@ class JUnitReporter(Reporter):
         :param scenario:  Scenario that was tested.
         :return: Textual description of the scenario.
         """
-        header_line  = u'\n@scenario.begin\n'
+        header_line = u'\n@scenario.begin\n'
+        tags = scenario.tags
+        header_line = '\n  %s\n' % ' '.join(['@%s' % tag for tag in tags])
         header_line += '  %s: %s\n' % (scenario.keyword, scenario.name)
-        footer_line  = u'\n@scenario.end\n' + u'-' * 80 + '\n'
+        footer_line = u'\n@scenario.end\n' + u'-' * 80 + '\n'
         text = u''
         for step in scenario:
             text += cls.describe_step(step)


### PR DESCRIPTION
expose tags within the output of the junit xml report so that generating
test results reports can reference the tags
