### PR TITLE
Undefined step raises NotImplementedError instead of assert False.

### DIFF
--- a/behave/runner_util.py
+++ b/behave/runner_util.py
@@ -363,7 +363,7 @@ def make_undefined_step_snippet(step, language=None):
     if single_quote in step.name:
         step.name = step.name.replace(single_quote, r"\'")
 
-    schema = u"@%s(%s'%s')\ndef step_impl(context):\n    assert False\n\n"
+    schema = u"@%s(%s'%s')\ndef step_impl(context):\n    raise NotImplementedError()\n\n"
     snippet = schema % (step.step_type, prefix, step.name)
     return snippet
 


### PR DESCRIPTION
Seems like a good idea.  Doesn't seem to break any tests.
