### PR TITLE
Allow setup.cfg as configuration file

### DIFF
--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -401,7 +401,7 @@ def load_configuration(defaults, verbose=False):
         paths.append(os.path.join(os.environ['APPDATA']))
 
     for path in paths:
-        for filename in 'behave.ini .behaverc'.split():
+        for filename in ('behave.ini', '.behaverc', 'setup.cfg'):
             filename = os.path.join(path, filename)
             if os.path.isfile(filename):
                 if verbose:

--- a/docs/behave.rst
+++ b/docs/behave.rst
@@ -178,8 +178,8 @@ you have to use logical AND::
 Configuration Files
 ===================
 
-Configuration files for *behave* are called either ".behaverc" or
-"behave.ini" (your preference) and are located in one of three places:
+Configuration files for *behave* are called either ".behaverc", "behave.ini",
+or "setup.cfg" (your preference) and are located in one of three places:
 
 1. the current working directory (good for per-project settings),
 2. your home directory ($HOME), or
@@ -188,7 +188,7 @@ Configuration files for *behave* are called either ".behaverc" or
 If you are wondering where *behave* is getting its configuration defaults
 from you can use the "-v" command-line argument and it'll tell you.
 
-Confuguration files **must** start with the label "[behave]" and are
+Configuration files **must** start with the label "[behave]" and are
 formatted in the Windows INI style, for example:
 
 .. code-block:: ini


### PR DESCRIPTION
Make behave look for the `setup.cfg` file (a commonly used configuration file, typically in combination with distutils or setuptools) in addition.
