### PR TITLE
fixed the logic of the CommandResult.failed() method

### DIFF
--- a/behave4cmd0/command_shell.py
+++ b/behave4cmd0/command_shell.py
@@ -53,7 +53,7 @@ class CommandResult(object):
 
     @property
     def failed(self):
-        return not self.returncode
+        return self.returncode != 0
 
     def clear(self):
         self.command = None


### PR DESCRIPTION
A command is successful if its return code is zero. Therefore the
evaluation of the return code must be reversed

Signed-off-by: bernhard ber.droid@googlemail.com
