### PR TITLE
Build improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 python:
   - 2.6
   - 2.7
@@ -7,7 +8,7 @@ python:
   - pypy
 
 install:
-  - pip install --use-mirrors -q mock nose PyHamcrest
+  - travis_retry pip install -q mock nose PyHamcrest
   - python setup.py -q install
 script:
   - python --version


### PR DESCRIPTION
The new dockerized build worker boots up faster and there's no reason not to use it since we don't need sudo.
Also --use-mirrors is deprecated. I replaced it with travis_retry which will retry executing a command on failure 3 times before failing.
