### PR TITLE
Feature/background hooks

### DIFF
--- a/behave/model.py
+++ b/behave/model.py
@@ -656,6 +656,51 @@ class Scenario(TagAndStatusStatement, Replayable):
             self.set_status(Status.skipped)
         assert self.status in self.final_status #< skipped, failed or passed
 
+    def _run_steps(self, steps, run_steps, runner, failed,
+                   dry_run_scenario):
+        for step in steps:
+            if run_steps:
+                if not step.run(runner):
+                    # -- CASE: Failed or undefined step
+                    #    Optionally continue_after_failed_step if enabled.
+                    #    But disable run_steps after undefined-step.
+                    run_steps = (self.continue_after_failed_step and
+                                 step.status == Status.failed)
+                    failed = True
+                    # pylint: disable=protected-access
+                    runner.context._set_root_attribute("failed", True)
+                    self.set_status(Status.failed)
+                elif self.should_skip:
+                    # -- CASE: Step skipped remaining scenario.
+                    # assert self.status == Status.skipped
+                    run_steps = False
+            elif failed or dry_run_scenario:
+                # -- SKIP STEPS: After failure/undefined-step occurred.
+                # BUT: Detect all remaining undefined steps.
+                step.status = Status.skipped
+                if dry_run_scenario:
+                    # pylint: disable=redefined-variable-type
+                    step.status = Status.untested
+                    found_step_match = runner.step_registry.find_match(step)
+                if not found_step_match:
+                    step.status = Status.undefined
+                    runner.undefined_steps.append(step)
+                elif dry_run_scenario:
+                    # -- BETTER DIAGNOSTICS: Provide step file location
+                    # (when --format=pretty is used).
+                    assert step.status == Status.untested
+                    for formatter in runner.formatters:
+                        # -- EMULATE: Step.run() protocol w/o step execution.
+                        formatter.match(found_step_match)
+                        formatter.result(step)
+            else:
+                # -- SKIP STEPS: For disabled scenario.
+                # CASES:
+                #   * Undefined steps are not detected (by intention).
+                #   * Step skipped remaining scenario.
+                step.status = Status.skipped
+        return failed, run_steps
+
     def run(self, runner):
         # pylint: disable=too-many-branches, too-many-statements
         self.clear_status()
@@ -700,54 +745,21 @@ class Scenario(TagAndStatusStatement, Replayable):
                 for formatter in runner.formatters:
                     formatter.step(step)
 
-        # Run background hooks, then steps
-        if self.background:
-            runner.run_hook('before_background', runner.context, self)
-        
-        # Run main steps
-
+        # Run background steps & hooks
         if not skip_scenario_untested:
-            for step in self.all_steps:
-                if run_steps:
-                    if not step.run(runner):
-                        # -- CASE: Failed or undefined step
-                        #    Optionally continue_after_failed_step if enabled.
-                        #    But disable run_steps after undefined-step.
-                        run_steps = (self.continue_after_failed_step and
-                                     step.status == Status.failed)
-                        failed = True
-                        # pylint: disable=protected-access
-                        runner.context._set_root_attribute("failed", True)
-                        self.set_status(Status.failed)
-                    elif self.should_skip:
-                        # -- CASE: Step skipped remaining scenario.
-                        # assert self.status == Status.skipped
-                        run_steps = False
-                elif failed or dry_run_scenario:
-                    # -- SKIP STEPS: After failure/undefined-step occurred.
-                    # BUT: Detect all remaining undefined steps.
-                    step.status = Status.skipped
-                    if dry_run_scenario:
-                        # pylint: disable=redefined-variable-type
-                        step.status = Status.untested
-                    found_step_match = runner.step_registry.find_match(step)
-                    if not found_step_match:
-                        step.status = Status.undefined
-                        runner.undefined_steps.append(step)
-                    elif dry_run_scenario:
-                        # -- BETTER DIAGNOSTICS: Provide step file location
-                        # (when --format=pretty is used).
-                        assert step.status == Status.untested
-                        for formatter in runner.formatters:
-                            # -- EMULATE: Step.run() protocol w/o step execution.
-                            formatter.match(found_step_match)
-                            formatter.result(step)
-                else:
-                    # -- SKIP STEPS: For disabled scenario.
-                    # CASES:
-                    #   * Undefined steps are not detected (by intention).
-                    #   * Step skipped remaining scenario.
-                    step.status = Status.skipped
+            if self.background:
+                runner.run_hook('before_background', runner.context, self)
+                failed, run_steps = \
+                    self._run_steps(self.background_steps,
+                                    run_steps,
+                                    runner,
+                                    failed,
+                                    dry_run_scenario)
+                runner.run_hook('after_background', runner.context, self)
+
+            # Run main steps
+            failed, run_steps = self._run_steps(self.steps, run_steps, runner,
+                                                failed, dry_run_scenario)
 
         self.clear_status()  # -- ENFORCE: compute_status() after run.
         if not run_scenario and not self.steps:

--- a/behave/model.py
+++ b/behave/model.py
@@ -700,6 +700,12 @@ class Scenario(TagAndStatusStatement, Replayable):
                 for formatter in runner.formatters:
                     formatter.step(step)
 
+        # Run background hooks, then steps
+        if self.background:
+            runner.run_hook('before_background', runner.context, self)
+        
+        # Run main steps
+
         if not skip_scenario_untested:
             for step in self.all_steps:
                 if run_steps:

--- a/behave/runner.py
+++ b/behave/runner.py
@@ -182,6 +182,14 @@ class Context(object):
                       PendingDeprecationWarning, stacklevel=2)
         return self.use_with_user_mode()
 
+    def get_stack(self):
+        return self._stack[0]
+
+    def set_stack(self, new_values):
+        for k, v in new_values.items():
+            if k not in self._stack[0]:
+                self._stack[0][k] = v
+            
     def _set_root_attribute(self, attr, value):
         for frame in self.__dict__["_stack"]:
             if frame is self.__dict__["_root"]:

--- a/docs/context_attributes.rst
+++ b/docs/context_attributes.rst
@@ -55,6 +55,7 @@ Hook    :func:`before_all`          test run
 Hook    :func:`after_all`           test run
 Hook    :func:`before_tags`         feature or scenario
 Hook    :func:`after_tags`          feature or scenario
+Hook    :func:`before_background`   feature
 Hook    :func:`before_feature`      feature
 Hook    :func:`after_feature`       feature
 Hook    :func:`before_scenario`     scenario

--- a/docs/context_attributes.rst
+++ b/docs/context_attributes.rst
@@ -56,6 +56,7 @@ Hook    :func:`after_all`           test run
 Hook    :func:`before_tags`         feature or scenario
 Hook    :func:`after_tags`          feature or scenario
 Hook    :func:`before_background`   feature
+Hook    :func:`after_background`    feature
 Hook    :func:`before_feature`      feature
 Hook    :func:`after_feature`       feature
 Hook    :func:`before_scenario`     scenario

--- a/issue.features/background_hook.feature
+++ b/issue.features/background_hook.feature
@@ -1,0 +1,74 @@
+@feature_request
+@background_hook
+Feature: Issue #290: Call before/after_background_hooks when running backgrounds
+
+  Provide environment hooks before_background and after_background to
+  allow eg. caching of complicated backgrounds
+
+  Background:
+    Given a new working directory
+    And a file named "features/steps/steps.py" with:
+        """
+        from behave import step
+
+        @step('a background step')
+        def background_step(context):
+            print ('background_step')
+
+        @step('{step_name} step fails')
+        def step_fails(context, step_name):
+            print (step_name+' step')
+            assert False
+
+        @step('{step_name} step succeeds')
+        def step_fails(context, step_name):
+            print (step_name+' step')
+        """
+    And a file named "features/backgroundhook_example.feature" with
+        """
+        Feature:
+
+          Background:
+            Given a background step
+
+          Scenario: A scenario
+            Given a step succeeds
+
+          Scenario: Another scenario to check hook fired twice
+            Given another step fails
+        """
+        
+  Scenario: before_background_hook is called before given step
+    Given a file named "features/environment.py" with
+        """
+        def before_background(context, feature):
+            print ('before_background hook called')
+        """
+    When I run "behave -f plain --no-capture features/backgroundhook_example.feature"
+    Then it should fail
+    And the command output should contain:
+        """
+        Scenario: A scenario
+        before_background hook called
+        background_step
+        Given a background step ... passed
+        a step
+        Given a step succeeds ... passed
+        """
+        
+     And the command output should contain:
+        """
+        Scenario: Another scenario to check hook fired twice
+        before_background hook called
+        background_step
+        Given a background step ... passed
+        another step
+        Given another step fails ... failed
+        """
+
+    And the command output should contain:
+        """
+        0 features passed, 1 failed, 0 skipped
+        1 scenario passed, 1 failed, 0 skipped
+        3 steps passed, 1 failed, 0 skipped, 0 undefined
+        """

--- a/issue.features/background_hook.feature
+++ b/issue.features/background_hook.feature
@@ -37,11 +37,11 @@ Feature: Issue #290: Call before/after_background_hooks when running backgrounds
           Scenario: Another scenario to check hook fired twice
             Given another step fails
         """
-        
+
   Scenario: before_background_hook is called before given step
     Given a file named "features/environment.py" with
         """
-        def before_background(context, feature):
+        def before_background(context, background):
             print ('before_background hook called')
         """
     When I run "behave -f plain --no-capture features/backgroundhook_example.feature"
@@ -62,6 +62,41 @@ Feature: Issue #290: Call before/after_background_hooks when running backgrounds
         before_background hook called
         background_step
         Given a background step ... passed
+        another step
+        Given another step fails ... failed
+        """
+
+    And the command output should contain:
+        """
+        0 features passed, 1 failed, 0 skipped
+        1 scenario passed, 1 failed, 0 skipped
+        3 steps passed, 1 failed, 0 skipped, 0 undefined
+        """
+
+  Scenario: after_background_hook is called after given step
+    Given a file named "features/environment.py" with
+        """
+        def after_background(context, background):
+            print ("after_background hook called")
+        """
+    When I run "behave -f plain --no-capture features/backgroundhook_example.feature"
+    Then it should fail
+     And the command output should contain:
+        """
+        Scenario: A scenario
+        background_step
+        Given a background step ... passed
+        after_background hook called
+        a step
+        Given a step succeeds ... passed
+        """
+
+     And the command output should contain:
+        """
+        Scenario: Another scenario to check hook fired twice
+        background_step
+        Given a background step ... passed
+        after_background hook called
         another step
         Given another step fails ... failed
         """

--- a/issue.features/background_hook.feature
+++ b/issue.features/background_hook.feature
@@ -107,3 +107,48 @@ Feature: Issue #290: Call before/after_background_hooks when running backgrounds
         1 scenario passed, 1 failed, 0 skipped
         3 steps passed, 1 failed, 0 skipped, 0 undefined
         """
+
+  @thisone
+  Scenario: before_background_hook can skip the background
+    Given a file named "features/environment.py" with
+        """
+        _background_count = 0
+        def before_background(context, background):
+            global _background_count
+            if _background_count > 0:
+               background.skip()
+            _background_count += 1
+            print ('before_background hook called')
+
+        def after_background(context, background):
+            print ('after_background hook called')
+        """
+    When I run "behave -f plain --no-capture features/backgroundhook_example.feature"
+    Then it should fail
+    And the command output should contain:
+        """
+        Scenario: A scenario
+        before_background hook called
+        background_step
+        Given a background step ... passed
+        after_background hook called
+        a step
+        Given a step succeeds ... passed
+        """
+
+     And the command output should contain:
+        """
+        Scenario: Another scenario to check hook fired twice
+        before_background hook called
+        Given a background step ... skipped
+        after_background hook called
+        another step
+        Given another step fails ... failed
+        """
+
+    And the command output should contain:
+        """
+        0 features passed, 1 failed, 0 skipped
+        1 scenario passed, 1 failed, 0 skipped
+        2 steps passed, 1 failed, 1 skipped, 0 undefined
+        """


### PR DESCRIPTION
Sometimes backgrounds get very expensive and it would be nice to be able to, for instance, run them once, dump the database afterwards (but before any further steps) and then reuse that for the remaining runs.

this PR adds before_background, after_background hooks for environment.py and a Background.skip() 
