### PR TITLE
fix fork me image in docs

### DIFF
--- a/docs/_themes/kr/layout.html
+++ b/docs/_themes/kr/layout.html
@@ -12,6 +12,6 @@
       &copy; Copyright {{ copyright }}.
     </div>
     <a href="https://github.com/behave/behave" class="github">
-        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://a248.e.akamai.net/assets.github.com/img/abad93f42020b733148435e2cd92ce15c542d320/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677265656e5f3030373230302e706e67" alt="Fork me on GitHub"  class="github"/>
+      <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
     </a>
 {%- endblock %}


### PR DESCRIPTION
I noticed the "fork me" image was broken.  Seems like other users were using these:

https://github.com/blog/273-github-ribbons

