### PR TITLE
step_registry: allow given <scenario> steps

### DIFF
--- a/behave/model.py
+++ b/behave/model.py
@@ -680,6 +680,7 @@ class Scenario(TagAndStatusStatement, Replayable):
         self.was_dry_run = False
         self.stderr = None
         self.stdout = None
+        step_registry.registry.scenarios[name] = self
 
     def reset(self):
         '''

--- a/behave/runner.py
+++ b/behave/runner.py
@@ -164,6 +164,14 @@ class Context(object):
             # -- NOTE: Otherwise skipped if AssertionError/Exception is raised.
             self._mode = self.BEHAVE
 
+    def get_stack(self):
+        return self._stack[0]
+
+    def set_stack(self, new_values):
+        for k, v in new_values.items():
+            if k not in self._stack[0]:
+                self._stack[0][k] = v
+            
     def _set_root_attribute(self, attr, value):
         for frame in self.__dict__['_stack']:
             if frame is self.__dict__['_root']:

--- a/behave/step_registry.py
+++ b/behave/step_registry.py
@@ -21,6 +21,7 @@ class StepRegistry(object):
             'then': [],
             'step': [],
         }
+        self.scenarios = {}
 
     @staticmethod
     def same_step_definition(step, other_string, other_location):
@@ -75,6 +76,18 @@ class StepRegistry(object):
             if result:
                 return result
 
+        if step.step_type == 'given':
+            # lookup scenario named with this step name
+            from behave import model
+            if step.name in self.scenarios:
+                scenario = self.scenarios[step.name]
+                to_exec = ['{step_type} {name}'.format(
+                    step_type=s.step_type,
+                    name=s.name)
+                           for s in scenario.steps]
+                def new_given_step(context):
+                    context.execute_steps(u'\n'.join(to_exec))
+                return model.Match(new_given_step, [])
         return None
 
     def make_decorator(self, step_type):
@@ -86,7 +99,6 @@ class StepRegistry(object):
                 return func
             return wrapper
         return decorator
-
 
 registry = StepRegistry()
 

--- a/issue.features/given_scenarios.feature
+++ b/issue.features/given_scenarios.feature
@@ -1,0 +1,59 @@
+@feature_request
+@issue
+Feature: Issue #XXX: Back reference features as givens
+
+  In some cases features and scenarios naturally build on each other,
+  e.g. logging in as an admin is one scenario, creating a user
+  involves logging in as an admin and then doing something
+  else. Creating a business object involves creating an admin and
+  creating a user and so on.
+
+  In order to DRY out the Gherkin for this and avoid steps which
+  duplicate the steps in a seperate place, allow users to write Given
+  steps which reference a previous scenario and executes those steps
+
+  Background:
+    Given a new working directory
+    And a file named "features/steps/steps.py" with:
+        """
+        from behave import step
+
+        @step('step {count}')
+        def a_step(context, count):
+            print ('step %s' % count)
+        """
+        
+    And a file named "features/given_scenario.feature" with
+        """
+        Feature:
+          
+          Scenario: Scenario 1
+            Given step 1
+            When step 2
+            Then step 3
+
+          Scenario: Scenario 2
+            Given Scenario 1
+            Then step 4
+        """
+
+  
+  Scenario: Refer to previous scenario
+    When I run "behave -c -f plain --no-capture features/given_scenario.feature"
+    Then it should pass with
+    """
+    Scenario: Scenario 1
+      step 1
+          Given step 1 ... passed
+      step 2
+          When step 2 ... passed
+      step 3
+          Then step 3 ... passed
+    Scenario: Scenario 2
+      step 1
+      step 2
+      step 3
+          Given Scenario 1 ... passed
+      step 4
+          Then step 4 ... passed
+    """


### PR DESCRIPTION
Sometimes it's a useful shorthand to refer back to previously
implemented scenarios as given steps for linear increments in
functionality
