### PR TITLE
Fix merge mistakes from commit 0c1d1f0

### DIFF
--- a/docs/behave.rst
+++ b/docs/behave.rst
@@ -284,8 +284,8 @@ you have to use logical AND::
 Configuration Files
 ===================
 
-Configuration files for *behave* are called either ".behaverc" or
-"behave.ini" (your preference) and are located in one of three places:
+Configuration files for *behave* are called either ".behaverc", "behave.ini",
+or "setup.cfg" (your preference) and are located in one of three places:
 
 1. the current working directory (good for per-project settings),
 2. your home directory ($HOME), or
@@ -294,11 +294,11 @@ Configuration files for *behave* are called either ".behaverc" or
 If you are wondering where *behave* is getting its configuration defaults
 from you can use the "-v" command-line argument and it'll tell you.
 
-Confuguration files **must** start with the label "[behave]" and are
+Configuration files **must** start with the label "[behave]" and are
 formatted in the Windows INI style, for example:
 
 .. code-block:: ini
-  
+
   [behave]
   format=plain
   logging_clear_handlers=yes

--- a/docs/gherkin.rst
+++ b/docs/gherkin.rst
@@ -85,7 +85,7 @@ line:
 
   Note that with this approach, if you want to execute *behave* without having
   to explicitly specify the directory (first option) you can set the ``paths``
-  setting in your `configuration file`_ (e.g. ``paths=tests/features``).
+  setting in your `configuration file`_ (e.g. ``paths=tests``).
 
 If you're having trouble setting things up and want to see what *behave* is
 doing in attempting to find your features use the "-v" (verbose)

--- a/docs/gherkin.rst
+++ b/docs/gherkin.rst
@@ -422,7 +422,7 @@ Or you can make it read more fluently by writing:
      Then I see something
       But I don't see something else
 
-The two scenarios are identical to *bevave* - steps beginning with "and" or
+The two scenarios are identical to *behave* - steps beginning with "and" or
 "but" are exactly the same kind of steps as all the others. They simply
 mimic the step that preceeds them.
 


### PR DESCRIPTION
This PR re-applies changes from PR #261 (additional configuration file `setup.cfg`) lost in a later merge.

Also, the changes originally from PR #260 (proposed setting in configuration file) now better match the example code block above the note.