### PR TITLE
Don't include skipped scenarios in junit reports if -k is specified

### DIFF
--- a/behave/reporter/junit.py
+++ b/behave/reporter/junit.py
@@ -279,7 +279,7 @@ class JUnitReporter(Reporter):
             text += _text(step.error_message)
             failure.append(CDATA(text))
             case.append(failure)
-        elif scenario.status in ('skipped', 'untested'):
+        elif scenario.status in ('skipped', 'untested') and self.config.show_skipped:
             report.counts_skipped += 1
             step = self.select_step_with_status('undefined', scenario)
             if step:
@@ -312,7 +312,8 @@ class JUnitReporter(Reporter):
             stderr.append(CDATA(text))
             case.append(stderr)
 
-        report.testcases.append(case)
+        if scenario.status != 'skipped' or self.config.show_skipped:
+            report.testcases.append(case)
 
     def _process_scenario_outline(self, scenario_outline, report):
         assert isinstance(scenario_outline, ScenarioOutline)

--- a/issue.features/issue0330.feature
+++ b/issue.features/issue0330.feature
@@ -1,0 +1,53 @@
+@issue
+Feature: Issue #330 Skipped scenarios are included in junit reports when -k is specified
+
+  @setup
+  Scenario: Feature Setup
+    Given a new working directory
+    And a file named "features/steps/steps.py" with:
+      """
+      from behave import step
+
+      @step('a step passes')
+      def step_passes(context):
+          pass
+      """
+    And a file named "features/feature_matched.feature" with:
+      """
+      @tag1
+      Feature:
+        Scenario:
+          Given a step passes
+      """
+    And a file named "features/feature_not_matched.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given a step passes
+      """
+
+  Scenario: Junit report is not created with --no-skipped
+    When I run "behave --junit --junit-directory=test_results -t tag1 --no-skipped"
+    Then it should pass with:
+      """
+      1 feature passed, 0 failed, 1 skipped
+      """
+    And a file named "test_results/TESTS-feature_matched.xml" exists
+    And a file named "test_results/TESTS-feature_not_matched.xml" exists
+    And the file "test_results/TESTS-feature_not_matched.xml" should contain
+    """
+    <testsuite errors="0" failures="0" name="feature_not_matched.feature_not_matched" skipped="0" tests="1" time="0.0" />
+    """
+
+  Scenario: Junit report is created with default options
+    When I run "behave --junit --junit-directory=test_results -t tag1"
+    Then it should pass with:
+      """
+      1 feature passed, 0 failed, 1 skipped
+      """
+    And a file named "test_results/TESTS-feature_matched.xml" exists
+    And a file named "test_results/TESTS-feature_not_matched.xml" exists
+    And the file "test_results/TESTS-feature_not_matched.xml" should contain
+    """
+     <testsuite errors="0" failures="0" name="feature_not_matched.feature_not_matched" skipped="1" tests="1" time="0.0">
+    """


### PR DESCRIPTION
Fixes #330 