### PR TITLE
Fix execute_steps() example

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -154,7 +154,7 @@ This function allows you to, for example:
 
     @when('I do the same thing as before')
     def step_impl(context):
-        context.execute_steps('''
+        context.execute_steps(u'''
             when I press the big red button
              and I duck
         ''')


### PR DESCRIPTION
When I tried to use `execute_steps()` as shown in the example, I was
getting an assertion about the steps needing to be in unicode.

`Assertion Failed: Steps must be unicode.`

It seems that the argument passed to `execute_steps()` must be a unicode
string otherwise it will not run.

This change updates the example for that method to show you must
provide a unicode string.

Signed-off-by: Micah Abbott <miabbott@redhat.com>