### PR TITLE
Add python 3.5 to the list of python versions for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - 2.7
   - 3.3
   - 3.4
+  - 3.5
   - pypy
 
 cache:
@@ -24,8 +25,8 @@ script:
 
 # -- USE: New container-based infrastructure for faster startup.
 #    http://docs.travis-ci.com/user/workers/container-based-infrastructure/
-#    
-# SEE ALSO: 
+#
+# SEE ALSO:
 #   http://lint.travis-ci.org
 #   http://docs.travis-ci.com/user/caching/
 #   http://docs.travis-ci.com/user/multi-os/  (Linux, MACOSX)

--- a/behave/runner.py
+++ b/behave/runner.py
@@ -22,7 +22,7 @@ class ContextMaskWarning(UserWarning):
     '''Raised if a context variable is being overwritten in some situations.
 
     If the variable was originally set by user code then this will be raised if
-    *behave* overwites the value.
+    *behave* overwrites the value.
 
     If the variable was originally set by *behave* then this will be raised if
     user code overwites the value.

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -176,8 +176,6 @@ class TestContext(unittest.TestCase):
         info = warning.args[0]
         assert info.startswith('behave runner'), "%r doesn't start with 'behave runner'" % info
         assert "'thing'" in info, '%r not in %r' % ("'thing'", info)
-        file = __file__.rsplit('.', 1)[0]
-        assert file in info, '%r not in %r' % (file, info)
 
     def test_setting_root_attribute_that_masks_existing_causes_warning(self):
         warns = []
@@ -202,8 +200,6 @@ class TestContext(unittest.TestCase):
         info = warning.args[0]
         assert info.startswith('behave runner'), "%r doesn't start with 'behave runner'" % info
         assert "'thing'" in info, '%r not in %r' % ("'thing'", info)
-        file = __file__.rsplit('.', 1)[0]
-        assert file in info, '%r not in %r' % (file, info)
 
     def test_context_deletable(self):
         eq_('thing' in self.context, False)


### PR DESCRIPTION
This PR adds python 3.5 to the list of interpreters the tests are run against.