### PR TITLE
Importing range from six.moves fails - Fix

### DIFF
--- a/behave/formatter/pretty.py
+++ b/behave/formatter/pretty.py
@@ -7,7 +7,13 @@ from behave.model_describe import escape_cell, escape_triple_quotes
 from behave.textutil import indent, text as _text
 import sys
 import six
-from six.moves import range
+
+# if importing range from six.moves fails
+# use python inbuilt range method
+try:
+    from six.moves import range
+except:
+    pass
 from six.moves import zip
 
 

--- a/behave/model_describe.py
+++ b/behave/model_describe.py
@@ -4,7 +4,14 @@ Provides textual descriptions for :mod:`behave.model` elements.
 """
 
 from __future__ import absolute_import
-from six.moves import range     # pylint: disable=redefined-builtin
+
+# When importing range from six.moves fails
+# use python's inbuilt range method
+try:
+    from six.moves import range     # pylint: disable=redefined-builtin
+except:
+    pass
+
 from six.moves import zip       # pylint: disable=redefined-builtin
 from behave.textutil import indent
 


### PR DESCRIPTION
Fix to make sure ImportError does not occur when trying to import range from six.moves.
If ImportError occurs, use the inbuilt python range method