### PR TITLE
sphinx.steps formatter: Support ref link for each step

### DIFF
--- a/behave/formatter/sphinx_steps.py
+++ b/behave/formatter/sphinx_steps.py
@@ -294,6 +294,13 @@ The following step definitions are provided here.
         self.document.write("%s\n" % step_definition_doc)
         self.document.write("\n")
 
+        # Add step label
+        from docutils.nodes import fully_normalize_name
+        step_text = fully_normalize_name(step_text)
+        step_lable = ".. _" + step_text + ":" + "\n"
+        self.document.write(step_lable)
+        self.document.write("\n")
+
 
 # -----------------------------------------------------------------------------
 # CLASS: SphinxStepsFormatter


### PR DESCRIPTION
adding a Cross-referencing arbitrary locations for each step.
enables the user adding a quick link to behave step!

```rst
# -- FILE: some_textfile.rst
use - :ref:`<step_name>`
```

ReST example:
```rst
For more details see step:  :ref:`When my step do "{something}"`.
```