### PR TITLE
Multiple step directories

### DIFF
--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -99,6 +99,12 @@ options = [
      dict(metavar="PATTERN", dest="include_re",
           help="Only run feature files matching regular expression PATTERN.")),
 
+    (("--extra-steps",),
+     dict(metavar="PATH", action="append", dest="extra_step_paths",
+          help="""Load extra step definitions from given path (directory). Can
+                  be specified multiple times.
+                  """)),
+
     (("--no-junit",),
      dict(action="store_false", dest="junit",
           help="Don't output JUnit-compatible reports.")),
@@ -569,6 +575,7 @@ class Configuration(object):
         self.exclude_re = None
         self.scenario_outline_annotation_schema = None  # pylint: disable=invalid-name
         self.steps_dir = "steps"
+        self.extra_step_paths = []
         self.environment_file = "environment.py"
         self.userdata_defines = None
         self.more_formatters = None

--- a/behave/runner.py
+++ b/behave/runner.py
@@ -761,7 +761,9 @@ class Runner(ModelRunner):
     def run_with_paths(self):
         self.context = Context(self)
         self.load_hooks()
-        self.load_step_definitions()
+        self.load_step_definitions(
+            extra_step_paths=self.config.extra_step_paths
+        )
 
         # -- ENSURE: context.execute_steps() works in weird cases (hooks, ...)
         # self.setup_capture()


### PR DESCRIPTION
Hello,

As I've commented on [issue 428](https://github.com/behave/behave/issues/428), I need to be able to specify multiple step directories. Let me know if that is desired feature in behave community.

Usage:

```
$ behave --extra-steps ../global-steps/net --extra-steps ../global-steps/files
```