### PR TITLE
Force color formating

### DIFF
--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -496,7 +496,7 @@ class Configuration(object):
     """Configuration object for behave and behave runners."""
     # pylint: disable=too-many-instance-attributes
     defaults = dict(
-        color=sys.platform != "win32",
+        color=TermColor.auto if sys.platform != "win32" else TermColor.never,
         show_snippets=True,
         show_skipped=True,
         dry_run=False,

--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -8,7 +8,6 @@ import re
 import sys
 import shlex
 import six
-from enum import Enum
 from six.moves import configparser
 
 from behave.model import ScenarioOutline
@@ -17,6 +16,7 @@ from behave.reporter.junit import JUnitReporter
 from behave.reporter.summary import SummaryReporter
 from behave.tag_expression import TagExpression
 from behave.formatter.base import StreamOpener
+from behave.formatter.pretty import TermColor
 from behave.formatter import _registry as _format_registry
 from behave.userdata import UserData, parse_user_define
 from behave._types import Unknown
@@ -70,21 +70,6 @@ class ConfigError(Exception):
 # -----------------------------------------------------------------------------
 # CONFIGURATION SCHEMA:
 # -----------------------------------------------------------------------------
-
-class TermColor(Enum):
-    never = 0
-    always  = 1
-    auto = 2
-
-    @staticmethod
-    def from_str(name):
-        try:
-            name = name.strip().lower()
-            return TermColor.__members__[name]
-        except KeyError:
-            allowed = ", ".join(TermColor.__members__.keys())
-            raise ValueError("INVALID COLOR: %s (allowed: %s)" % (name, allowed))
-
 
 options = [
     (("-c", "--no-color"),

--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -8,6 +8,7 @@ import re
 import sys
 import shlex
 import six
+from enum import Enum
 from six.moves import configparser
 
 from behave.model import ScenarioOutline
@@ -69,13 +70,31 @@ class ConfigError(Exception):
 # -----------------------------------------------------------------------------
 # CONFIGURATION SCHEMA:
 # -----------------------------------------------------------------------------
+
+class TermColor(Enum):
+    never = 0
+    always  = 1
+    auto = 2
+
+    @staticmethod
+    def from_str(name):
+        try:
+            name = name.strip().lower()
+            return TermColor.__members__[name]
+        except KeyError:
+            allowed = ", ".join(TermColor.__members__.keys())
+            raise ValueError("INVALID COLOR: %s (allowed: %s)" % (name, allowed))
+
+
 options = [
     (("-c", "--no-color"),
-     dict(action="store_false", dest="color",
+     dict(action="store_const", dest="color", default=argparse.SUPPRESS,
+          const=TermColor.never,
           help="Disable the use of ANSI color escapes.")),
 
     (("--color",),
-     dict(action="store_true", dest="color",
+     dict(action="store", dest="color", nargs='?', type=TermColor.from_str,
+          const=TermColor.auto,
           help="""Use ANSI color escapes. This is the default
                   behaviour. This switch is used to override a
                   configuration file setting.""")),

--- a/behave/formatter/pretty.py
+++ b/behave/formatter/pretty.py
@@ -14,7 +14,7 @@ from six.moves import zip
 
 class TermColor(Enum):
     never = 0
-    always  = 1
+    always = 1
     auto = 2
 
     @staticmethod

--- a/behave/formatter/pretty.py
+++ b/behave/formatter/pretty.py
@@ -1,6 +1,7 @@
 # -*- coding: utf8 -*-
 
 from __future__ import absolute_import, division
+from enum import Enum
 from behave.formatter.ansi_escapes import escapes, up
 from behave.formatter.base import Formatter
 from behave.model_describe import escape_cell, escape_triple_quotes
@@ -10,6 +11,20 @@ import six
 from six.moves import range
 from six.moves import zip
 
+
+class TermColor(Enum):
+    never = 0
+    always  = 1
+    auto = 2
+
+    @staticmethod
+    def from_str(name):
+        try:
+            name = name.strip().lower()
+            return TermColor.__members__[name]
+        except KeyError:
+            allowed = ", ".join(TermColor.__members__.keys())
+            raise ValueError("INVALID COLOR: %s (allowed: %s)" % (name, allowed))
 
 # -----------------------------------------------------------------------------
 # TERMINAL SUPPORT:

--- a/behave/formatter/pretty.py
+++ b/behave/formatter/pretty.py
@@ -81,9 +81,17 @@ class PrettyFormatter(Formatter):
         super(PrettyFormatter, self).__init__(stream_opener, config)
         # -- ENSURE: Output stream is open.
         self.stream = self.open()
-        isatty = getattr(self.stream, "isatty", lambda: True)
-        stream_supports_colors = isatty()
-        self.monochrome = not config.color or not stream_supports_colors
+
+        if config.color == TermColor.always:
+            self.monochrome = False
+        elif config.color == TermColor.never:
+            self.monochrome = True
+        else:
+            assert config.color == TermColor.auto
+            isatty = getattr(self.stream, "isatty", lambda: True)
+            stream_supports_colors = isatty()
+            self.monochrome = not config.color or not stream_supports_colors
+
         self.show_source = config.show_source
         self.show_timings = config.show_timings
         self.show_multiline = config.show_multiline

--- a/behave/formatter/pretty.py
+++ b/behave/formatter/pretty.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division
 from enum import Enum

--- a/test/test_formatter.py
+++ b/test/test_formatter.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 import struct
 import sys

--- a/test/test_formatter.py
+++ b/test/test_formatter.py
@@ -10,6 +10,7 @@ from nose.tools import *    # pylint: disable=wildcard-import, unused-wildcard-i
 
 from behave.formatter._registry import make_formatters
 from behave.formatter import pretty
+from behave.formatter.pretty import TermColor
 from behave.formatter.base import StreamOpener
 from behave.model import Tag, Feature, Scenario, Step
 from behave.matchers import Match
@@ -99,7 +100,7 @@ class FormatterTests(unittest.TestCase):
 
     def setUp(self):
         self.config = Mock()
-        self.config.color = True
+        self.config.color = TermColor.auto
         self.config.outputs = [StreamOpener(stream=sys.stdout)]
         self.config.format = [self.formatter_name]
 
@@ -210,7 +211,7 @@ class MultipleFormattersTests(FormatterTests):
 
     def setUp(self):
         self.config = Mock()
-        self.config.color = True
+        self.config.color = TermColor.auto
         self.config.outputs = [StreamOpener(stream=sys.stdout)
                                for i in self.formatters]
         self.config.format = self.formatters


### PR DESCRIPTION
Hi, I did some work on color formatting options. It's not finished yet, but I'd like to share my findings and get some feedback.

These changes partially solves my issue - it is possible to get color output even using pipes. Unfortunately PrettyFormatter assumes that it is writing to terminal if ``self.monochrome`` set to ``False``, which doesn't work well with pipes. Basically what I need:
- pretty formatter without terminal functionality
- or plain formatter with colors

## Proposal

- I'd like to create PlainColorFormater which would inherit from Plain (solves my problem).
- Later refactor PrettyFormatter to inherit from PlainColorFormater, because conceptually plain and pretty formatters do the same thing (unless there is a really really good technical reason why it should not be so).

![formatter inheritance chain](http://yuml.me/78cc7dff)

Benefits of this approach:

- PrettyFormater only deals with terminal output.
- PlainColorFormater only adds color to PlainFormater.
- PlainFormater only deals with textual output.
- Potentially reduces code duplication.

## Notes

It is possible to use [unbuffer](http://expect.sourceforge.net/example/unbuffer.man.html) tool to fix this, though it is additional dependency that I really want to avoid.

Issue is reproducible with `behave --color=always features/background.feature | less -R`.