### PR TITLE
Read behave settings from tox.ini as an additional alternative

### DIFF
--- a/behave.ini
+++ b/behave.ini
@@ -1,7 +1,7 @@
 # =============================================================================
 # BEHAVE CONFIGURATION
 # =============================================================================
-# FILE: .behaverc, behave.ini
+# FILE: .behaverc, behave.ini, setup.cfg, tox.ini
 #
 # SEE ALSO:
 #  * http://packages.python.org/behave/behave.html#configuration-files

--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -26,6 +26,7 @@ ConfigParser = configparser.ConfigParser
 if six.PY2:
     ConfigParser = configparser.SafeConfigParser
 
+
 # -----------------------------------------------------------------------------
 # CONFIGURATION DATA TYPES:
 # -----------------------------------------------------------------------------
@@ -62,8 +63,6 @@ class LogLevel(object):
 
 class ConfigError(Exception):
     pass
-
-
 
 
 # -----------------------------------------------------------------------------
@@ -445,7 +444,8 @@ def config_filenames():
         paths.append(os.path.join(os.environ["APPDATA"]))
 
     for path in reversed(paths):
-        for filename in reversed(("behave.ini", ".behaverc", "setup.cfg", "tox.ini")):
+        for filename in reversed(
+                ("behave.ini", ".behaverc", "setup.cfg", "tox.ini")):
             filename = os.path.join(path, filename)
             if os.path.isfile(filename):
                 yield filename
@@ -465,7 +465,7 @@ def load_configuration(defaults, verbose=False):
 
 def setup_parser():
     # construct the parser
-    #usage = "%(prog)s [options] [ [FILE|DIR|URL][:LINE[:LINE]*] ]+"
+    # usage = "%(prog)s [options] [ [FILE|DIR|URL][:LINE[:LINE]*] ]+"
     usage = "%(prog)s [options] [ [DIR|FILE|FILE:LINE] ]+"
     description = """\
     Run a number of feature tests with behave."""
@@ -487,6 +487,7 @@ def setup_parser():
     parser.add_argument("paths", nargs="*",
                         help="Feature directory, file or file location (FILE:LINE).")
     return parser
+
 
 class Configuration(object):
     """Configuration object for behave and behave runners."""

--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -445,7 +445,7 @@ def config_filenames():
         paths.append(os.path.join(os.environ["APPDATA"]))
 
     for path in reversed(paths):
-        for filename in reversed(("behave.ini", ".behaverc", "setup.cfg")):
+        for filename in reversed(("behave.ini", ".behaverc", "setup.cfg", "tox.ini")):
             filename = os.path.join(path, filename)
             if os.path.isfile(filename):
                 yield filename

--- a/docs/behave.rst
+++ b/docs/behave.rst
@@ -282,8 +282,8 @@ Configuration Files
 ===================
 
 Configuration files for *behave* are called either ".behaverc",
-"behave.ini" or "setup.cfg" (your preference) and are located in one of
-three places:
+"behave.ini", "setup.cfg" or "tox.ini" (your preference) and are located in
+one of three places:
 
 1. the current working directory (good for per-project settings),
 2. your home directory ($HOME), or


### PR DESCRIPTION
In addition to placing behave settings into `setup.cfg` (apart from the configuration files specifically dedicated to _behave_) behave user should have the possibility of adding settings to `tox.ini`, which a popular way for testing Python projects against different environments.

This way we give behave users the possibility to reduce excessive proliferation of configuration files in Python projects.
