### PR TITLE
Add status to scenarios in JSON report

### DIFF
--- a/behave/formatter/json.py
+++ b/behave/formatter/json.py
@@ -30,6 +30,7 @@ class JSONFormatter(Formatter):
         self.current_feature = None
         self.current_feature_data = None
         self._step_index = 0
+        self.previous_scenario = None
 
     def reset(self):
         self.current_feature = None
@@ -71,6 +72,10 @@ class JSONFormatter(Formatter):
             self.step(step_)
 
     def scenario(self, scenario):
+        if self.previous_scenario:
+            self.current_feature_element['status'] = self.previous_scenario.status
+        self.previous_scenario = scenario
+
         element = self.add_feature_element({
             'type': 'scenario',
             'keyword': scenario.keyword,
@@ -78,6 +83,7 @@ class JSONFormatter(Formatter):
             'tags': scenario.tags,
             'location': six.text_type(scenario.location),
             'steps': [],
+            'status': scenario.status
         })
         if scenario.description:
             element['description'] = scenario.description
@@ -193,6 +199,10 @@ class JSONFormatter(Formatter):
         """
         if not self.current_feature_data:
             return
+
+        # -- Update status of last scenario
+        if self.previous_scenario:
+            self.current_feature_element['status'] = self.previous_scenario.status
 
         # -- NORMAL CASE: Write collected data of current feature.
         self.update_status_data()

--- a/features/formatter.json.feature
+++ b/features/formatter.json.feature
@@ -129,6 +129,7 @@ Feature: JSON Formatter
                     "keyword": "Scenario",
                     "location": "features/simple_scenario.feature:2",
                     "name": "Simple scenario without steps",
+                    "status": "passed",
                     "steps": [],
                     "tags": [],
                     "type": "scenario"
@@ -174,6 +175,7 @@ Feature: JSON Formatter
                     "keyword": "Scenario",
                     "location": "features/simple_scenario_with_description.feature:2",
                     "name": "Simple scenario with description but without steps",
+                    "status": "passed",
                     "steps": [],
                     "tags": [],
                     "type": "scenario"
@@ -212,6 +214,7 @@ Feature: JSON Formatter
                     "keyword": "Scenario",
                     "location": "features/simple_scenario_with_tags.feature:5",
                     "name": "Simple scenario with tags but without steps",
+                    "status": "passed",
                     "steps": [],
                     "tags": [
                       "foo",


### PR DESCRIPTION
When running behave with the json formatter no status was assigned to scenarios.
This change adds a method to the formatter which gets called at the end of a scenario (eos). The json formatter uses this to add the final status of a scenario to the json output.