### PR TITLE
Plain color formatter

### DIFF
--- a/behave/formatter/_builtins.py
+++ b/behave/formatter/_builtins.py
@@ -13,6 +13,7 @@ from behave.formatter import _registry
 # SCHEMA: formatter.name, formatter.class(_name)
 _BUILTIN_FORMATS = [
     ("plain",   "behave.formatter.plain:PlainFormatter"),
+    ("plain.color", "behave.formatter.plain_color:PlainColorFormatter"),
     ("pretty",  "behave.formatter.pretty:PrettyFormatter"),
     ("json",    "behave.formatter.json:JSONFormatter"),
     ("json.pretty", "behave.formatter.json:PrettyJSONFormatter"),

--- a/behave/formatter/plain_color.py
+++ b/behave/formatter/plain_color.py
@@ -3,6 +3,7 @@
 from behave.formatter.ansi_escapes import escapes
 from behave.formatter.plain import PlainFormatter
 from behave.textutil import make_indentation
+from behave.textutil import make_indentation
 
 
 class PlainColorFormatter(PlainFormatter):
@@ -33,6 +34,17 @@ class PlainColorFormatter(PlainFormatter):
         step = self.steps.pop(0)
         assert step == result_step
         self.print_step(result_step)
+
+    def feature(self, feature):
+        super(PlainColorFormatter, self).feature(feature)
+
+        if feature.description:
+            self.stream.write('\n')
+
+        for line in feature.description:
+            self.stream.write(make_indentation(self.indent_size))
+            self.stream.write(line)
+            self.stream.write('\n')
 
     def eof(self, *args, **kwargs):
         self.print_not_executed_steps()

--- a/behave/formatter/plain_color.py
+++ b/behave/formatter/plain_color.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from behave.formatter.ansi_escapes import escapes
 from behave.formatter.plain import PlainFormatter
 from behave.textutil import make_indentation

--- a/behave/formatter/plain_color.py
+++ b/behave/formatter/plain_color.py
@@ -32,6 +32,10 @@ class PlainColorFormatter(PlainFormatter):
         assert step == result_step
         self.print_step(result_step)
 
+    def eof(self, *args, **kwargs):
+        self.print_not_executed_steps()
+        return super().eof(*args, **kwargs)
+
     def print_step(self, step, executed=True):
         indent = make_indentation(2 * self.indent_size)
         plain_text = self.step_format % (indent, step.keyword, step.name)
@@ -73,7 +77,3 @@ class PlainColorFormatter(PlainFormatter):
     def print_not_executed_steps(self):
         for step in self.steps:
             self.print_step(step, executed=False)
-
-    def eof(self, *args, **kwargs):
-        self.print_not_executed_steps()
-        return super().eof(*args, **kwargs)

--- a/behave/formatter/plain_color.py
+++ b/behave/formatter/plain_color.py
@@ -66,3 +66,11 @@ class PlainColorFormatter(PlainFormatter):
                 self.doc_string(step.text)
             if step.table:
                 self.table(step.table)
+
+    def print_not_executed_steps(self):
+        for step in self.steps:
+            self.print_step(step, executed=False)
+
+    def eof(self, *args, **kwargs):
+        self.print_not_executed_steps()
+        return super().eof(*args, **kwargs)

--- a/behave/formatter/plain_color.py
+++ b/behave/formatter/plain_color.py
@@ -41,9 +41,11 @@ class PlainColorFormatter(PlainFormatter):
         if feature.description:
             self.stream.write('\n')
 
-        for line in feature.description:
-            self.stream.write(make_indentation(self.indent_size))
-            self.stream.write(line)
+            for line in feature.description:
+                self.stream.write(make_indentation(self.indent_size))
+                self.stream.write(line)
+                self.stream.write('\n')
+
             self.stream.write('\n')
 
     def eof(self, *args, **kwargs):

--- a/behave/formatter/plain_color.py
+++ b/behave/formatter/plain_color.py
@@ -3,7 +3,6 @@
 from behave.formatter.ansi_escapes import escapes
 from behave.formatter.plain import PlainFormatter
 from behave.textutil import make_indentation
-from behave.textutil import make_indentation
 
 
 class PlainColorFormatter(PlainFormatter):
@@ -22,9 +21,9 @@ class PlainColorFormatter(PlainFormatter):
     SHOW_ALIGNED_KEYWORDS = True
     SHOW_TAGS = True
 
-
     def __init__(self, stream_opener, config, **kwargs):
-        super(PlainColorFormatter, self).__init__(stream_opener, config, **kwargs)
+        super(PlainColorFormatter, self).__init__(
+            stream_opener, config, **kwargs)
         self.step_format = u"%s%s %s "
 
         if self.show_aligned_keywords:

--- a/behave/formatter/plain_color.py
+++ b/behave/formatter/plain_color.py
@@ -4,7 +4,14 @@ from behave.textutil import make_indentation
 
 
 class PlainColorFormatter(PlainFormatter):
-    """For environments with ansi color support but wihtout terminal support"""
+    """For environments with ansi color support but wihtout terminal support
+
+    Use case examples that support ansi colors:
+
+       * Emacs compilation buffer.
+       * Jenkins build output.
+       * less.
+    """
 
     name = 'plain.color'
     description = "Plain formater with ansi colors."

--- a/behave/formatter/plain_color.py
+++ b/behave/formatter/plain_color.py
@@ -1,0 +1,44 @@
+from behave.formatter.ansi_escapes import escapes
+from behave.formatter.plain import PlainFormatter
+from behave.textutil import make_indentation
+
+
+class PlainColorFormatter(PlainFormatter):
+    """For environments with ansi color support but wihtout terminal support"""
+
+    name = 'plain.color'
+
+    SHOW_ALIGNED_KEYWORDS = True
+    SHOW_TAGS = True
+
+    def result(self, result):
+        step = self.steps.pop(0)
+        indent = make_indentation(2 * self.indent_size)
+
+        if self.show_aligned_keywords:
+            # -- RIGHT-ALIGN KEYWORDS (max. keyword width: 6):
+            plain_text = u"%s%6s %s " % (indent, step.keyword, step.name)
+        else:
+            plain_text = u"%s%s %s " % (indent, step.keyword, step.name)
+
+        text = escapes[result.status] + plain_text + escapes['reset']
+        self.stream.write(text)
+
+        status = result.status
+        if self.show_timings:
+            status += " in %0.3fs" % step.duration
+
+        term_width = 80
+        text_width = term_width - len(plain_text) - len(status) - len('... ')
+        whitespace_len = max(1, text_width)
+        whitespace = ' ' * whitespace_len
+        self.stream.write(u"%s... %s\n" % (whitespace, status))
+
+        if result.error_message:
+            self.stream.write(u"%s\n" %result.error_message)
+
+        if self.show_multiline:
+            if step.text:
+                self.doc_string(step.text)
+            if step.table:
+                self.table(step.table)

--- a/behave/formatter/plain_color.py
+++ b/behave/formatter/plain_color.py
@@ -82,7 +82,10 @@ class PlainColorFormatter(PlainFormatter):
         self.stream.write('\n')
 
         if step.error_message:
-            self.stream.write(u"%s\n" %step.error_message)
+            for line in step.error_message.split('\n'):
+                self.stream.write(make_indentation(self.indent_size * 4))
+                self.stream.write(line)
+                self.stream.write('\n')
 
         if self.show_multiline:
             if step.text:

--- a/behave/formatter/plain_color.py
+++ b/behave/formatter/plain_color.py
@@ -12,11 +12,13 @@ class PlainColorFormatter(PlainFormatter):
 
        * Emacs compilation buffer.
        * Jenkins build output.
-       * less.
+       * less -R|--RAW-CONTROL-CHARS.
     """
 
     name = 'plain.color'
-    description = "Plain formater with ansi colors."
+    description = (
+        'For environments with ANSI color support but wihtout terminal support'
+    )
 
     SHOW_ALIGNED_KEYWORDS = True
     SHOW_TAGS = True

--- a/behave/formatter/plain_color.py
+++ b/behave/formatter/plain_color.py
@@ -7,6 +7,7 @@ class PlainColorFormatter(PlainFormatter):
     """For environments with ansi color support but wihtout terminal support"""
 
     name = 'plain.color'
+    description = "Plain formater with ansi colors."
 
     SHOW_ALIGNED_KEYWORDS = True
     SHOW_TAGS = True

--- a/behave/formatter/plain_color.py
+++ b/behave/formatter/plain_color.py
@@ -19,6 +19,14 @@ class PlainColorFormatter(PlainFormatter):
     SHOW_ALIGNED_KEYWORDS = True
     SHOW_TAGS = True
 
+
+    def __init__(self, stream_opener, config, **kwargs):
+        super(PlainColorFormatter, self).__init__(stream_opener, config, **kwargs)
+        self.step_format = u"%s%s %s "
+
+        if self.show_aligned_keywords:
+            self.step_format = u"%s%6s %s "
+
     def result(self, result_step):
         step = self.steps.pop(0)
         assert step == result_step
@@ -26,12 +34,7 @@ class PlainColorFormatter(PlainFormatter):
 
     def print_step(self, step, executed=True):
         indent = make_indentation(2 * self.indent_size)
-
-        if self.show_aligned_keywords:
-            # -- RIGHT-ALIGN KEYWORDS (max. keyword width: 6):
-            plain_text = u"%s%6s %s " % (indent, step.keyword, step.name)
-        else:
-            plain_text = u"%s%s %s " % (indent, step.keyword, step.name)
+        plain_text = self.step_format % (indent, step.keyword, step.name)
 
         # pretty formater prints not executed steps as skipped
         status = step.status if executed else 'skipped'

--- a/features/formatter.help.feature
+++ b/features/formatter.help.feature
@@ -15,6 +15,7 @@ Feature: Help Formatter
         json.pretty    JSON dump of test run (human readable)
         null           Provides formatter that does not output anything.
         plain          Very basic formatter with maximum compatibility
+        plain.color    Plain formater with ansi colors.
         pretty         Standard colourised pretty formatter
         progress       Shows dotted progress for each executed scenario.
         progress2      Shows dotted progress for each executed step.

--- a/features/formatter.help.feature
+++ b/features/formatter.help.feature
@@ -15,7 +15,7 @@ Feature: Help Formatter
         json.pretty    JSON dump of test run (human readable)
         null           Provides formatter that does not output anything.
         plain          Very basic formatter with maximum compatibility
-        plain.color    Plain formater with ansi colors.
+        plain.color    For environments with ANSI color support but wihtout terminal support
         pretty         Standard colourised pretty formatter
         progress       Shows dotted progress for each executed scenario.
         progress2      Shows dotted progress for each executed step.

--- a/issue.features/issue0031.feature
+++ b/issue.features/issue0031.feature
@@ -12,5 +12,6 @@ Feature: Issue #31 "behave --format help" raises an error
         json.pretty    JSON dump of test run (human readable)
         null           Provides formatter that does not output anything.
         plain          Very basic formatter with maximum compatibility
+        plain.color    Plain formater with ansi colors.
         pretty         Standard colourised pretty formatter
       """

--- a/issue.features/issue0031.feature
+++ b/issue.features/issue0031.feature
@@ -12,6 +12,6 @@ Feature: Issue #31 "behave --format help" raises an error
         json.pretty    JSON dump of test run (human readable)
         null           Provides formatter that does not output anything.
         plain          Very basic formatter with maximum compatibility
-        plain.color    Plain formater with ansi colors.
+        plain.color    For environments with ANSI color support but wihtout terminal support
         pretty         Standard colourised pretty formatter
       """


### PR DESCRIPTION
This is mostly for environments without terminal functionality support, such as emacs compilation buffer or jenkins. Also works with pipes `behave -f plain.color | less -R`.

I also tried to use --color=always approach, but pretty formatter requires terminal support.
