### PR TITLE
changed the scenario naming format to reference row attributes

### DIFF
--- a/behave/model.py
+++ b/behave/model.py
@@ -797,9 +797,8 @@ class ScenarioOutlineBuilder(object):
                 self.id = name      # pylint: disable=invalid-name
 
         example_data = Data(examples_name, example.index)
-        row_data = Data(row.id, row.index)
-        return self.annotation_schema.format(name=scenario_name,
-                                             examples=example_data, row=row_data)
+        return self.annotation_schema.replace('{row.name}', '{row.id}').format(
+            name=scenario_name, examples=example_data, row=row)
 
     @classmethod
     def make_row_tags(cls, outline_tags, row, params=None):


### PR DESCRIPTION
changed the scenario naming format to reference row attributes

I want these two annotation schemas to work, and this change makes that happen.
annotation_schema = u"{name} -- @{row.id} {row[0]}"
annotation_schema = u"{name} -- @{row.id} {row[NAME]}"
