### PR TITLE
Update model.py to print step implementation location

### DIFF
--- a/behave/model.py
+++ b/behave/model.py
@@ -708,7 +708,7 @@ class Scenario(TagAndStatusStatement, Replayable):
                 if not found_step:
                     step.status = "undefined"
                     runner.undefined_steps.append(step)
-                elif dry_run_scenario:                    
+                elif dry_run_scenario:
                     for formatter in runner.formatters:
                         formatter.match(found_step)
             else:

--- a/behave/model.py
+++ b/behave/model.py
@@ -708,6 +708,9 @@ class Scenario(TagAndStatusStatement, Replayable):
                 if not found_step:
                     step.status = "undefined"
                     runner.undefined_steps.append(step)
+                elif dry_run_scenario:                    
+                    for formatter in runner.formatters:
+                        formatter.match(found_step)
             else:
                 # -- SKIP STEPS: For disabled scenario.
                 # CASES:


### PR DESCRIPTION
This is a proposal to extend the dry-run feature so as to print the step implementation location to help developer to locate the step implementation in step.py quickly. Tracking issue #459 . 