### PR TITLE
1.2.5 didn't support activated virtualenv

### DIFF
--- a/setuptools_behave.py
+++ b/setuptools_behave.py
@@ -16,13 +16,14 @@ Setuptools command for behave.
     * http://github.com/behave/behave
 """
 
-from setuptools import Command
-from distutils import dir_util
-from fnmatch import fnmatch
 import os.path
-import sys
 import shlex
 import subprocess
+import sys
+
+from distutils import dir_util
+from fnmatch import fnmatch
+from setuptools import Command
 
 
 class behave_test(Command):
@@ -114,7 +115,10 @@ class behave_test(Command):
         return returncode
 
     def behave(self, path):
-        behave = os.path.join("bin", "behave")
+        binpath = "bin"
+        if "VIRTUAL_ENV" in os.environ:
+            binpath = "{0}/bin".format(os.environ.get("VIRTUAL_ENV"))
+        behave = os.path.join(binpath, "behave")
         if not os.path.exists(behave):
             # -- ALTERNATIVE: USE: behave script: behave = "behave"
             # -- USE: behave module (main)


### PR DESCRIPTION
I found [this answer](http://stackoverflow.com/questions/21698004/python-behave-integration-in-setuptools-setup-py#answer-22901706) on Stackoverflow and realized `setuptools_behave` doesn't work in a virtualenv environment. My solution only addresses a one-off and thus is not ideal, but I wanted to get the ball rolling on this, so others could maybe point out a better direction.

[Maybe something like this is better?](https://github.com/python-standard-library-examples/subprocess.python.standard-library.examples/blob/b96a5b8896902544a0781a96c75dcab8d52fd2df/python/subprocess/Popen(args%2C%20bufsize%3D0%2C%20executable%3DNone%2C%20stdin%3DNone%2C%20stdout%3DNone%2C%20stderr%3DNone%2C%20preexec_fn%3DNone%2C%20close_fds%3DFalse%2C%20shell%3DFalse%2C%20cwd%3DNone%2C%20env%3DNone%2C%20universal_newlines%3DFalse%2C%20startupinfo%3DNone%2C%20creationflags%3D0)/Popen(%5B%22which%22%5D)/distutils.spawn.find_executable())

```python
from distutils.spawn import find_executable
import os.path

binpath = os.path.dirname(find_executable('python'))
```

Of course, I'm not sure how the latter would address things like python3 in a non-virtualenv environment.

Any thoughts? Cheers!