### PR TITLE
convert an object to unicode (py2) using __unicode__ method first

### DIFF
--- a/behave/textutil.py
+++ b/behave/textutil.py
@@ -75,8 +75,11 @@ def text(value, encoding=None, errors=None):
         # -- CONVERT OBJECT TO TEXT:
         try:
             if six.PY2:
-                data = str(value)
-                text = six.text_type(data, "unicode-escape", "replace")
+                try:
+                    text = six.text_type(value)
+                except UnicodeError:
+                    data = str(value)
+                    text = six.text_type(data, "unicode-escape", "replace")
             else:
                 text = six.text_type(value)
         except UnicodeError as e:


### PR DESCRIPTION
use case: text(AssertionError(u"some unicode string àèìòù")) raised a UnicodeError because it naively tried to call str() on a unicode object.

Since AssertionError defines its own __unicode__ method, it is convenient to delegate Unicode conversion to it.

Old text() behaviour is maintained for objects not defining a __unicode__ method