### PR TITLE
behave4cmd0/command_shell: remove executable flag

### DIFF
--- a/behave4cmd0/command_shell.py
+++ b/behave4cmd0/command_shell.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
 Provide a behave shell to simplify creation of feature files


### PR DESCRIPTION
It's better to have it without executable flag if we will distribute
it as module.

Signed-off-by: Igor Gnatenko ignatenko@redhat.com
