### PR TITLE
Fix link to Selenium docs in Django chapter (docs)

### DIFF
--- a/docs/django.rst
+++ b/docs/django.rst
@@ -111,7 +111,7 @@ details. Example using :pypi:`behave-django`:
     def step_impl(context, url):
         context.browser.get(context.get_url(url))
 
-.. _Selenium docs: http://selenium.googlecode.com/git/docs/api/py/api.html
+.. _Selenium docs: https://seleniumhq.github.io/selenium/docs/api/py/api.html
 
 
 Splinter (Example)


### PR DESCRIPTION
This PR updates a now dangling link to the Selenium documentation for Python. (Google Code has been discontinued, the Selenium project and its docs are now hosted on GitHub.)