### PR TITLE
Add the --order option to behave

### DIFF
--- a/behave/model.py
+++ b/behave/model.py
@@ -15,6 +15,7 @@ import copy
 import difflib
 import logging
 import itertools
+import random
 import time
 import six
 from six.moves import zip       # pylint: disable=redefined-builtin
@@ -309,6 +310,8 @@ class Feature(TagAndStatusStatement, Replayable):
             if self.background:
                 for formatter in runner.formatters:
                     formatter.background(self.background)
+
+        order_list_by_config(runner.config, self.scenarios)
 
         if not skip_feature_untested:
             for scenario in self.scenarios:
@@ -1735,3 +1738,12 @@ def reset_model(model_elements):
     """
     for model_element in model_elements:
         model_element.reset()
+
+
+def order_list_by_config(config, iterable):
+    order_type, seed = config.order
+    if order_type != "random":
+        return iterable
+    r = random.Random(seed)
+    r.shuffle(iterable)
+    return iterable

--- a/behave/reporter/summary.py
+++ b/behave/reporter/summary.py
@@ -74,6 +74,10 @@ class SummaryReporter(Reporter):
                     scenario.location, scenario.name))
             self.stream.write("\n")
 
+        if self.config.order[0] == 'random':
+            randomized = "Randomized with seed: %d\n" % self.config.order[1]
+            self.stream.write(randomized)
+
         # -- SHOW SUMMARY COUNTS:
         self.stream.write(format_summary("feature", self.feature_summary))
         self.stream.write(format_summary("scenario", self.scenario_summary))

--- a/behave/runner.py
+++ b/behave/runner.py
@@ -17,6 +17,7 @@ from behave.configuration import ConfigError
 from behave.capture import CaptureController
 from behave.runner_util import collect_feature_locations, parse_features
 from behave._types import ExceptionUtil
+from behave.model import order_list_by_config
 if six.PY2:
     # -- USE PYTHON3 BACKPORT: With unicode traceback support.
     import traceback2 as traceback
@@ -531,6 +532,9 @@ class ModelRunner(object):
         run_feature = not self.aborted
         failed_count = 0
         undefined_steps_initial_size = len(self.undefined_steps)
+
+        order_list_by_config(self.config, features)
+
         for feature in features:
             if run_feature:
                 try:

--- a/features/runner.order.feature
+++ b/features/runner.order.feature
@@ -1,0 +1,101 @@
+@sequential
+Feature: Default Formatter
+
+  . SPECIFICATION:
+  .  * Default defined order is used when no `--order` configuration is set.
+  .  * Steps are in random order when no `--order random` configuration is set.
+
+
+    Background:
+      Given a new working directory
+      And a file named "features/steps/passing_steps.py" with:
+        """
+        from behave import step
+
+        @step('a step passes')
+        def step_passes(context):
+            pass
+        """
+      And a file named "features/alice.feature" with:
+        """
+        Feature: Alice
+          Scenario: A1
+            Given a step passes
+            When a step passes
+            Then a step passes
+          Scenario: A2
+            Given a step passes
+            When a step passes
+            Then a step passes
+        """
+      And a file named "features/bob.feature" with:
+        """
+        Feature: Bob
+          Scenario: B1
+            When a step passes
+            Then a step passes
+          Scenario: B2
+            When a step passes
+            Then a step passes
+        """
+
+    @no_configfile
+    Scenario: The order of the scenarios are as defined
+      Given a file named "behave.ini" does not exist
+      When I run "behave -c features/"
+      Then it should pass with:
+        """
+        2 features passed, 0 failed, 0 skipped
+        4 scenarios passed, 0 failed, 0 skipped
+        """
+      And the command output should contain:
+        """
+        Feature: Alice # features/alice.feature:1
+          Scenario: A1          # features/alice.feature:2
+            Given a step passes # features/steps/passing_steps.py:3
+            When a step passes  # features/steps/passing_steps.py:3
+            Then a step passes  # features/steps/passing_steps.py:3
+          Scenario: A2          # features/alice.feature:6
+            Given a step passes # features/steps/passing_steps.py:3
+            When a step passes  # features/steps/passing_steps.py:3
+            Then a step passes  # features/steps/passing_steps.py:3
+
+        Feature: Bob # features/bob.feature:1
+          Scenario: B1         # features/bob.feature:2
+            When a step passes # features/steps/passing_steps.py:3
+            Then a step passes # features/steps/passing_steps.py:3
+          Scenario: B2         # features/bob.feature:5
+            When a step passes # features/steps/passing_steps.py:3
+            Then a step passes # features/steps/passing_steps.py:3
+        """
+
+    @no_configfile
+    Scenario: The order of the scenarios are as defined
+      Given a file named "behave.ini" does not exist
+      When I run "behave --order random:90 -c features/"
+      Then it should pass with:
+        """
+        Randomized with seed: 90
+        2 features passed, 0 failed, 0 skipped
+        4 scenarios passed, 0 failed, 0 skipped
+        """
+      And the command output should contain:
+        """
+        Feature: Bob # features/bob.feature:1
+          Scenario: B2         # features/bob.feature:5
+            When a step passes # features/steps/passing_steps.py:3
+            Then a step passes # features/steps/passing_steps.py:3
+          Scenario: B1         # features/bob.feature:2
+            When a step passes # features/steps/passing_steps.py:3
+            Then a step passes # features/steps/passing_steps.py:3
+
+        Feature: Alice # features/alice.feature:1
+          Scenario: A2          # features/alice.feature:6
+            Given a step passes # features/steps/passing_steps.py:3
+            When a step passes  # features/steps/passing_steps.py:3
+            Then a step passes  # features/steps/passing_steps.py:3
+          Scenario: A1          # features/alice.feature:2
+            Given a step passes # features/steps/passing_steps.py:3
+            When a step passes  # features/steps/passing_steps.py:3
+            Then a step passes  # features/steps/passing_steps.py:3
+        """

--- a/setup.py
+++ b/setup.py
@@ -114,5 +114,3 @@ setup(
     ],
     zip_safe = True,
 )
-
-

--- a/test/reporters/test_summary.py
+++ b/test/reporters/test_summary.py
@@ -74,6 +74,7 @@ class TestSummaryReporter(object):
         features[3].__iter__ = Mock(return_value=iter([]))
 
         config = Mock()
+        config.order = ('defined', None)
         reporter = SummaryReporter(config)
 
         [reporter.feature(f) for f in features]
@@ -109,6 +110,7 @@ class TestSummaryReporter(object):
         features[4].__iter__ = Mock(return_value=iter([]))
 
         config = Mock()
+        config.order = ('defined', None)
         reporter = SummaryReporter(config)
 
         [reporter.feature(f) for f in features]
@@ -144,6 +146,7 @@ class TestSummaryReporter(object):
         feature.__iter__ = Mock(return_value=iter(scenarios))
 
         config = Mock()
+        config.order = ('defined', None)
         reporter = SummaryReporter(config)
 
         reporter.feature(feature)
@@ -186,6 +189,7 @@ class TestSummaryReporter(object):
         feature.__iter__ = Mock(return_value=iter(scenarios))
 
         config = Mock()
+        config.order = ('defined', None)
         reporter = SummaryReporter(config)
 
         reporter.feature(feature)
@@ -224,6 +228,7 @@ class TestSummaryReporter(object):
         scenario.__iter__ = Mock(return_value=iter(steps))
 
         config = Mock()
+        config.order = ('defined', None)
         reporter = SummaryReporter(config)
 
         reporter.feature(feature)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -38,6 +38,7 @@ class TestFeatureRun(unittest.TestCase):
         self.runner.aborted = False
         self.runner.feature.tags = []
         self.config = self.runner.config = Mock()
+        self.config.order = ('defined', None)
         self.context = self.runner.context = Mock()
         self.formatters = self.runner.formatters = [Mock()]
         self.run_hook = self.runner.run_hook = Mock()

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -657,6 +657,7 @@ class TestRunWithPaths(unittest.TestCase):
         self.config.logging_filter = None
         self.config.outputs = [Mock(), StreamOpener(stream=sys.stdout)]
         self.config.format = ["plain", "progress"]
+        self.config.order = ('defined', None)
         self.runner = runner.Runner(self.config)
         self.load_hooks = self.runner.load_hooks = Mock()
         self.load_step_definitions = self.runner.load_step_definitions = Mock()
@@ -1071,4 +1072,3 @@ class TestFeatureDirectoryLayout2(object):
                 assert_raises(ConfigError, r.setup_paths)
 
         ok_(("isdir", os.path.join(fs.base, "features", "steps")) in fs.calls)
-


### PR DESCRIPTION
Hello Behave peeps,

Thanks for this project, we really like it and are using it a lot. There is, however, a feature missing that we at [Blendle](https://blendle.com) would really like: `--order random`

We mostly do Ruby development using [cucumber](https://github.com/cucumber/cucumber/) and we always run our tests in a random order. This lets us find a few bugs and forces us the make each scenario completely isolated.

This pull-request adds the `--order TYPE[:SEED]` option to the behave command. Possible types are `defined`(default) and `random`. When using the random order you have the option to pass along a set seed to reproduce issues in a previous run.

Hope you like the change! 
Cheers,
—Koen Bollen
