### PR TITLE
Unit test fix

### DIFF
--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -30,7 +30,7 @@ ROOTDIR_PREFIX = ""
 if sys.platform.startswith("win"):
     # -- OR: ROOTDIR_PREFIX = os.path.splitdrive(sys.executable)
     # NOTE: python2 requires lower-case drive letter.
-    ROOTDIR_PREFIX = os.environ.get("BEHAVE_ROOTDIR_PREFIX", "c:")
+    ROOTDIR_PREFIX = os.environ.get("BEHAVE_ROOTDIR_PREFIX", "C:")
 
 class TestConfiguration(object):
 


### PR DESCRIPTION
Running the tests on a Windows file system results in an error for `TestConfiguration.test_read_file`. This change fixes it.