### PR TITLE
add an option to fail on empty scenario outline

### DIFF
--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -146,6 +146,12 @@ options = [
                   This is the default behaviour. This switch is used to
                   override a configuration file setting.""")),
 
+     (("--fail-on-empty-scenario-outline",),
+      dict(action="store_true", dest="fail_on_empty_outline",
+           help="""A scenario outline fails if it has no examples
+                   This is not the default behavior. By default the scenario
+                   will be shown as skipped.""")),
+
     (("--no-snippets",),
      dict(action="store_false", dest="show_snippets",
           help="Don't print snippets for unimplemented steps.")),
@@ -496,6 +502,7 @@ class Configuration(object):
         color=sys.platform != "win32",
         show_snippets=True,
         show_skipped=True,
+        fail_on_empty_outline=False,
         dry_run=False,
         show_source=True,
         show_timings=True,

--- a/behave/model.py
+++ b/behave/model.py
@@ -1106,6 +1106,8 @@ class ScenarioOutline(Scenario):
                 if runner.config.stop or runner.aborted:
                     # -- FAIL-EARLY: Stop after first failure.
                     break
+        if not self.scenarios and runner.config.fail_on_empty_outline:
+            self.set_status(Status.failed)
         runner.context._set_root_attribute("active_outline", None)
         return failed_count > 0
 


### PR DESCRIPTION
If someone write a scenario outline without any scenario, in a feature, the feature silently passes, some use may want to fail in this case.