### PR TITLE
Fix PendingDeprecationWarning

### DIFF
--- a/behave/runner.py
+++ b/behave/runner.py
@@ -456,7 +456,7 @@ class ModelRunner(object):
     def run_hook(self, name, context, *args):
         if not self.config.dry_run and (name in self.hooks):
             try:
-                with context.user_mode():
+                with context.use_with_user_mode():
                     self.hooks[name](context, *args)
             # except KeyboardInterrupt:
             #     self.aborted = True


### PR DESCRIPTION
Currently, a warning is emitted very frequently in console output when running Behave due to the outdated use of user_mode() instead of use_with_user_mode(). This fix addresses that problem.