### PR TITLE
fix warning `Citation [TDD-Python] is not referenced.`

### DIFF
--- a/docs/more_info.rst
+++ b/docs/more_info.rst
@@ -50,12 +50,10 @@ Books
 
 `Behave`_ is covered in the following books:
 
-.. [TDD-Python] Harry Percival,
-    `Test-Driven Web Development with Python`_, O'Reilly, June 2014,
-    `Appendix E: BDD <http://chimera.labs.oreilly.com/books/1234000000754/ape.html>`_
-    (covers behave)
+* Harry Percival, `Test-Driven Web Development with Python`_, O'Reilly, June 2014, `Appendix E: BDD`_ (covers behave)
 
 .. _`Test-Driven Web Development with Python`: http://chimera.labs.oreilly.com/books/1234000000754
+.. _`Appendix E: BDD`: http://chimera.labs.oreilly.com/books/1234000000754/ape.html
 
 
 Presentation Videos


### PR DESCRIPTION
Got this error when building the docs with `tox -e docs`

_Warning, treated as error:
D:\behave\docs\more_info.rst:53:Citation [TDD-Python] is not referenced._

Fixed it by removing the reference in the Books section and followed how other references were added in Tutorials and Presentation Videos.