### PR TITLE
Steps-catalog argument should not break configured rerun settings

### DIFF
--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -589,7 +589,10 @@ class Configuration(object):
         if self.steps_catalog:
             # -- SHOW STEP-CATALOG: As step summary.
             self.default_format = "steps.catalog"
-            self.format = ["steps.catalog"]
+            if self.format:
+                self.format.append("steps.catalog")
+            else:
+                self.format = ["steps.catalog"]
             self.dry_run = True
             self.summary = False
             self.show_skipped = False

--- a/features/formatter.rerun.feature
+++ b/features/formatter.rerun.feature
@@ -294,3 +294,20 @@ Feature: Rerun Formatter
             features/bob.feature:13
             """
         And note that "the second RerunFormatter overwrites the output of the first one"
+
+    @with.behave_configfile
+    Scenario: RerunFormatter with steps-catalog
+        Given a file named "behave.ini" with:
+            """
+            [behave]
+            format   = rerun
+            outfiles = rerun.txt
+            """
+        When I run "behave --steps-catalog features/"
+
+        Then it should pass with:
+            """
+            Given a step passes
+            """
+        And a file named "rerun.txt" does not exist
+

--- a/features/formatter.steps_catalog.feature
+++ b/features/formatter.steps_catalog.feature
@@ -98,3 +98,16 @@ Feature: Steps Catalog Formatter
           """
         But note that "the step definitions are ordered by step type"
         And note that "'When I visit {person}' has no doc-string"
+
+
+    Scenario: Steps catalog formatter is used for output even when other formatter is specified
+        When I run "behave --steps-catalog -f plain features/"
+        Then it should pass with:
+          """
+          Given {person} lives in {city}
+              Setup the data where a person lives and store in the database.
+
+              :param person:  Person's name (as string).
+              :param city:    City where the person lives (as string).
+          """
+


### PR DESCRIPTION
We have a Behave configuration with the rerun formatter and a corresponding outfile. When we ran Behave with the --steps-catalog argument we realized that the rerun output file still got created, but with the steps-catalog output.

This pull request preserves the configured output file formatter coupling.