### PR TITLE
Allow forcing color with --color=always

### DIFF
--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -75,7 +75,7 @@ options = [
 
     (("--color",),
      dict(dest="color", choices=["never", "always", "auto"],
-          default="auto", const="auto", nargs="?",
+          default=None, const="auto", nargs="?",
           help="""Use ANSI color escapes. Defaults to %(const)r.
                   This switch is used to override a
                   configuration file setting.""")),
@@ -544,6 +544,16 @@ class Configuration(object):
         if verbose is None:
             # -- AUTO-DISCOVER: Verbose mode from command-line args.
             verbose = ("-v" in command_args) or ("--verbose" in command_args)
+
+        # Allow commands like `--color features/whizbang.feature` to work
+        # Without this, argparse will treat the positional arg as the value to
+        # --color and we'd get:
+        #   argument --color: invalid choice: 'features/whizbang.feature'
+        #   (choose from 'never', 'always', 'auto')
+        if '--color' in command_args:
+            color_arg_pos = command_args.index('--color')
+            if os.path.exists(command_args[color_arg_pos + 1]):
+                command_args.insert(color_arg_pos + 1, '--')
 
         self.version = None
         self.tags_help = None

--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -75,7 +75,7 @@ options = [
 
     (("--color",),
      dict(dest="color", choices=["never", "always", "auto"],
-          default=None, const="auto", nargs="?",
+          default=os.getenv('BEHAVE_COLOR'), const="auto", nargs="?",
           help="""Use ANSI color escapes. Defaults to %(const)r.
                   This switch is used to override a
                   configuration file setting.""")),
@@ -494,7 +494,7 @@ class Configuration(object):
     """Configuration object for behave and behave runners."""
     # pylint: disable=too-many-instance-attributes
     defaults = dict(
-        color=sys.platform != "win32",
+        color='never' if sys.platform == "win32" else os.getenv('BEHAVE_COLOR', 'auto'),
         show_snippets=True,
         show_skipped=True,
         dry_run=False,

--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -74,9 +74,10 @@ options = [
           help="Disable the use of ANSI color escapes.")),
 
     (("--color",),
-     dict(action="store_true", dest="color",
-          help="""Use ANSI color escapes. This is the default
-                  behaviour. This switch is used to override a
+     dict(dest="color", choices=["never", "always", "auto"],
+          default="auto", const="auto", nargs="?",
+          help="""Use ANSI color escapes. Defaults to %(const)r.
+                  This switch is used to override a
                   configuration file setting.""")),
 
     (("-d", "--dry-run"),

--- a/behave/formatter/pretty.py
+++ b/behave/formatter/pretty.py
@@ -66,9 +66,7 @@ class PrettyFormatter(Formatter):
         super(PrettyFormatter, self).__init__(stream_opener, config)
         # -- ENSURE: Output stream is open.
         self.stream = self.open()
-        isatty = getattr(self.stream, "isatty", lambda: True)
-        stream_supports_colors = isatty()
-        self.monochrome = not config.color or not stream_supports_colors
+        self.monochrome = self._get_monochrome(config)
         self.show_source = config.show_source
         self.show_timings = config.show_timings
         self.show_multiline = config.show_multiline
@@ -83,6 +81,14 @@ class PrettyFormatter(Formatter):
         self.indentations = []
         self.step_lines = 0
 
+    def _get_monochrome(self, config):
+        isatty = getattr(self.stream, "isatty", lambda: True)
+        if config.color == 'always':
+            return False
+        elif config.color == 'never':
+            return True
+        else:
+            return not isatty()
 
     def reset(self):
         # -- UNUSED: self.tag_statement = None


### PR DESCRIPTION
even if stdout is not a tty (e.g.: Jenkins)

This makes the `--color` option have an optional value of `never`, `always`, or `auto` (the default if no optional value is provided).

```
$ behave --help | grep --after=2 color
  -c, --no-color        Disable the use of ANSI color escapes.
  --color [{never,always,auto}]
                        Use ANSI color escapes. Defaults to 'auto'. This
                        switch is used to override a configuration file
                        setting.
```

Related: https://github.com/behave/behave/pull/450

Cc: @seanisom, @pavan18, @varshachandanb, @aisbaa