### PR TITLE
Plain color formatter

### DIFF
--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -511,7 +511,7 @@ class Configuration(object):
         stage=None,
         userdata={},
         # -- SPECIAL:
-        default_format="pretty",    # -- Used when no formatters are configured.
+        default_format=os.getenv("BEHAVE_FORMATTER", "pretty"),    # -- Used when no formatters are configured.
         default_tags="",            # -- Used when no tags are defined.
         scenario_outline_annotation_schema=u"{name} -- @{row.id} {examples.name}"
     )

--- a/behave/formatter/_builtins.py
+++ b/behave/formatter/_builtins.py
@@ -14,6 +14,7 @@ from behave.formatter import _registry
 _BUILTIN_FORMATS = [
     # pylint: disable=bad-whitespace
     ("plain",   "behave.formatter.plain:PlainFormatter"),
+    ("plain.color", "behave.formatter.plain_color:PlainColorFormatter"),
     ("pretty",  "behave.formatter.pretty:PrettyFormatter"),
     ("json",    "behave.formatter.json:JSONFormatter"),
     ("json.pretty", "behave.formatter.json:PrettyJSONFormatter"),

--- a/behave/formatter/plain_color.py
+++ b/behave/formatter/plain_color.py
@@ -2,6 +2,7 @@
 
 from behave.formatter.ansi_escapes import escapes
 from behave.formatter.plain import PlainFormatter
+from behave.model_core import Status
 from behave.textutil import make_indentation
 
 
@@ -58,13 +59,13 @@ class PlainColorFormatter(PlainFormatter):
         plain_text = self.step_format % (indent, step.keyword, step.name)
 
         # pretty formater prints not executed steps as skipped
-        status = step.status if executed else 'skipped'
+        status = step.status if executed else Status.skipped
+        status_text = status.name
 
         self.stream.write(
-            escapes[status] + plain_text + escapes['reset']
+            escapes[status_text] + plain_text + escapes['reset']
         )
 
-        status_text = status
         if self.show_timings:
             if executed:
                 status_text += " in %0.3fs" % step.duration

--- a/behave/formatter/plain_color.py
+++ b/behave/formatter/plain_color.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+
+from behave.formatter.ansi_escapes import escapes
+from behave.formatter.plain import PlainFormatter
+from behave.textutil import make_indentation
+
+
+class PlainColorFormatter(PlainFormatter):
+    """For environments with ansi color support but wihtout terminal support
+
+    Use case examples that support ansi colors:
+
+       * Emacs compilation buffer.
+       * Jenkins build output.
+       * less -R|--RAW-CONTROL-CHARS.
+    """
+
+    name = 'plain.color'
+    description = (
+        'For environments with ANSI color support but wihtout terminal support'
+    )
+
+    SHOW_ALIGNED_KEYWORDS = True
+    SHOW_TAGS = True
+
+    def __init__(self, stream_opener, config, **kwargs):
+        super(PlainColorFormatter, self).__init__(
+            stream_opener, config, **kwargs)
+        self.step_format = u"%s%s %s "
+
+        if self.show_aligned_keywords:
+            self.step_format = u"%s%6s %s "
+
+    def result(self, result_step):
+        step = self.steps.pop(0)
+        assert step == result_step
+        self.print_step(result_step)
+
+    def feature(self, feature):
+        super(PlainColorFormatter, self).feature(feature)
+
+        if feature.description:
+            self.stream.write('\n')
+
+            for line in feature.description:
+                self.stream.write(make_indentation(self.indent_size))
+                self.stream.write(line)
+                self.stream.write('\n')
+
+            self.stream.write('\n')
+
+    def eof(self, *args, **kwargs):
+        self.print_not_executed_steps()
+        return super().eof(*args, **kwargs)
+
+    def print_step(self, step, executed=True):
+        indent = make_indentation(2 * self.indent_size)
+        plain_text = self.step_format % (indent, step.keyword, step.name)
+
+        # pretty formater prints not executed steps as skipped
+        status = step.status if executed else 'skipped'
+
+        self.stream.write(
+            escapes[status] + plain_text + escapes['reset']
+        )
+
+        status_text = status
+        if self.show_timings:
+            if executed:
+                status_text += " in %0.3fs" % step.duration
+            else:
+                status_text += " in -.---s"
+
+        # creates nice indentation between end of step description and status
+        whitespace_width = 80
+        whitespace_width -= len(plain_text)
+        whitespace_width -= len(status_text)
+        whitespace_width -= len('... ')
+
+        self.stream.write(u" " * max(1, whitespace_width))
+        self.stream.write(u"... ")
+        self.stream.write(status_text)
+        self.stream.write('\n')
+
+        if step.error_message:
+            for line in step.error_message.split('\n'):
+                self.stream.write(make_indentation(self.indent_size * 4))
+                self.stream.write(line)
+                self.stream.write('\n')
+
+        if self.show_multiline:
+            if step.text:
+                self.doc_string(step.text)
+            if step.table:
+                self.table(step.table)
+
+    def print_not_executed_steps(self):
+        for step in self.steps:
+            self.print_step(step, executed=False)

--- a/behave/formatter/plain_color.py
+++ b/behave/formatter/plain_color.py
@@ -7,7 +7,7 @@ from behave.textutil import make_indentation
 
 
 class PlainColorFormatter(PlainFormatter):
-    """For environments with ansi color support but wihtout terminal support
+    """For environments with ansi color support but without terminal support
 
     Use case examples that support ansi colors:
 
@@ -18,7 +18,7 @@ class PlainColorFormatter(PlainFormatter):
 
     name = 'plain.color'
     description = (
-        'For environments with ANSI color support but wihtout terminal support'
+        'For environments with ANSI color support but without terminal support'
     )
 
     SHOW_ALIGNED_KEYWORDS = True

--- a/features/formatter.help.feature
+++ b/features/formatter.help.feature
@@ -15,6 +15,7 @@ Feature: Help Formatter
         json.pretty    JSON dump of test run (human readable)
         null           Provides formatter that does not output anything.
         plain          Very basic formatter with maximum compatibility
+        plain.color    For environments with ANSI color support but wihtout terminal support
         pretty         Standard colourised pretty formatter
         progress       Shows dotted progress for each executed scenario.
         progress2      Shows dotted progress for each executed step.

--- a/features/formatter.help.feature
+++ b/features/formatter.help.feature
@@ -15,7 +15,7 @@ Feature: Help Formatter
         json.pretty    JSON dump of test run (human readable)
         null           Provides formatter that does not output anything.
         plain          Very basic formatter with maximum compatibility
-        plain.color    For environments with ANSI color support but wihtout terminal support
+        plain.color    For environments with ANSI color support but without terminal support
         pretty         Standard colourised pretty formatter
         progress       Shows dotted progress for each executed scenario.
         progress2      Shows dotted progress for each executed step.

--- a/issue.features/issue0031.feature
+++ b/issue.features/issue0031.feature
@@ -12,5 +12,6 @@ Feature: Issue #31 "behave --format help" raises an error
         json.pretty    JSON dump of test run (human readable)
         null           Provides formatter that does not output anything.
         plain          Very basic formatter with maximum compatibility
+        plain.color    For environments with ANSI color support but wihtout terminal support
         pretty         Standard colourised pretty formatter
       """

--- a/issue.features/issue0031.feature
+++ b/issue.features/issue0031.feature
@@ -12,6 +12,6 @@ Feature: Issue #31 "behave --format help" raises an error
         json.pretty    JSON dump of test run (human readable)
         null           Provides formatter that does not output anything.
         plain          Very basic formatter with maximum compatibility
-        plain.color    For environments with ANSI color support but wihtout terminal support
+        plain.color    For environments with ANSI color support but without terminal support
         pretty         Standard colourised pretty formatter
       """


### PR DESCRIPTION
This is mostly for environments without terminal functionality support, such as emacs compilation buffer or jenkins. Also works with pipes, such as `behave -f plain.color | less -R`.

This is mostly the work of @aisbaa from #450 (thanks, @aisbaa!), along with a few tweaks to make it work with the latest `master` and to add a `BEHAVE_FORMATTER` env var, so one can call `BEHAVE_FORMATTER=plain.color behave ...` in their Jenkins job and it will activate color if the installed version of behave has this change and will just do monochrome and not fail if it's an old version of behave that doesn't have this change.

My use case was to have colored output in Jenkins, as shown below:

![screen shot 2017-08-03 at 9 13 48 pm](https://user-images.githubusercontent.com/305268/28954046-14308e62-7891-11e7-93b4-2b93b2e042c8.png)

Cc: @aisbaa, @jenisys, @seanisom, @pavan18, @varshachandanb