### PR TITLE
Avoid Behave failure when step is in a different Windows drive

### DIFF
--- a/behave/model_core.py
+++ b/behave/model_core.py
@@ -253,7 +253,12 @@ class FileLocation(object):
         line_number = function_code.co_firstlineno
 
         curdir = curdir or os.getcwd()
-        filename = os.path.relpath(filename, curdir)
+        # If a function (step) comes from a different disk drive in Windows a
+        # relative path will fail. In that case just keep the absolute path.
+        try:
+            filename = os.path.relpath(filename, curdir)
+        except ValueError:
+            pass
         return cls(filename, line_number)
 
 


### PR DESCRIPTION
If for some reason you need to import steps from a different Windows drive Behave will fail because it tries to obtain a relative path. This simple fix just fallbacks to the absolute path in those cases.