### PR TITLE
Make the pretty print better looking

### DIFF
--- a/behave/formatter/pretty.py
+++ b/behave/formatter/pretty.py
@@ -242,7 +242,9 @@ class PrettyFormatter(Formatter):
     def calculate_location_indentations(self):
         line_widths = []
         for s in [self.statement] + self.steps:
-            string = s.keyword + " " + s.name
+            # where 5 is the length of the longest keyword 'Given'
+            step_keyword = (' ' * (5 - len(s.keyword))) + s.keyword
+            string = step_keyword + " " + s.name
             line_widths.append(len(string))
         max_line_width = max(line_widths)
         self.indentations = [max_line_width - width for width in line_widths]
@@ -252,7 +254,7 @@ class PrettyFormatter(Formatter):
             return
 
         self.calculate_location_indentations()
-        self.stream.write(u"\n")
+        self.stream.write(u"\n\n")
         #self.print_comments(self.statement.comments, "  ")
         if hasattr(self.statement, "tags"):
             self.print_tags(self.statement.tags, u"  ")
@@ -281,8 +283,11 @@ class PrettyFormatter(Formatter):
 
         #self.print_comments(step.comments, "    ")
         self.stream.write("    ")
-        self.stream.write(text_format.text(step.keyword + " "))
-        line_length = 5 + len(step.keyword)
+
+        # where 5 is the length of the longest keyword 'Given'
+        step_keyword = (' ' * (5 - len(step.keyword))) + step.keyword
+        self.stream.write(text_format.text(step_keyword + " "))
+        line_length = 6 + len(step_keyword)
 
         step_name = six.text_type(step.name)
 


### PR DESCRIPTION
Before this change:

```
> behave issue.features/issue0030.feature
@issue
Feature: Issue #30 "behave --version" runs features and shows no version # issue.features/issue0030.feature:2

  Scenario: Ensure environment assumptions are correct (Sanity Check)  # issue.features/issue0030.feature:4
    Given a new working directory                                      # behave4cmd0/command_steps.py:84 0.000s
    When I run "behave"                                                # behave4cmd0/command_steps.py:142 0.059s
    Then it should fail                                                # behave4cmd0/command_steps.py:184 0.000s
    And the command output should contain                              # behave4cmd0/command_steps.py:314 0.000s
      """
      No steps directory in '{__WORKDIR__}/features'
      """

  Scenario: Ensure --version option is processed correctly  # issue.features/issue0030.feature:13
    Given a new working directory                           # behave4cmd0/command_steps.py:84 0.000s
    When I run "behave --version"                           # behave4cmd0/command_steps.py:142 0.061s
    Then it should pass                                     # behave4cmd0/command_steps.py:179 0.000s
    And the command output should not contain               # behave4cmd0/command_steps.py:330 0.000s
      """
      No steps directory in '{__WORKDIR__}/features'
      """

1 feature passed, 0 failed, 0 skipped
2 scenarios passed, 0 failed, 0 skipped
8 steps passed, 0 failed, 0 skipped, 0 undefined
Took 0m0.122s
```

After this change:

```
> behave issue.features/issue0030.feature
@issue
Feature: Issue #30 "behave --version" runs features and shows no version # issue.features/issue0030.feature:2

  Scenario: Ensure environment assumptions are correct (Sanity Check)  # issue.features/issue0030.feature:4
    Given a new working directory                                      # behave4cmd0/command_steps.py:84 0.000s
     When I run "behave"                                               # behave4cmd0/command_steps.py:142 0.061s
     Then it should fail                                               # behave4cmd0/command_steps.py:184 0.000s
      And the command output should contain                            # behave4cmd0/command_steps.py:314 0.000s
      """
      No steps directory in '{__WORKDIR__}/features'
      """

  Scenario: Ensure --version option is processed correctly  # issue.features/issue0030.feature:13
    Given a new working directory                           # behave4cmd0/command_steps.py:84 0.000s
     When I run "behave --version"                          # behave4cmd0/command_steps.py:142 0.061s
     Then it should pass                                    # behave4cmd0/command_steps.py:179 0.000s
      And the command output should not contain             # behave4cmd0/command_steps.py:330 0.000s
      """
      No steps directory in '{__WORKDIR__}/features'
      """

1 feature passed, 0 failed, 0 skipped
2 scenarios passed, 0 failed, 0 skipped
8 steps passed, 0 failed, 0 skipped, 0 undefined
Took 0m0.123s
```

As you can see the left side of the keywords: Given, When, Then and And
are nicely aligned to the right and the extra line of space between
Feature and Scenario also make it a little more consistent in styling.