### PR TITLE
Fix UnicodeDecodeErrors in Python 2

### DIFF
--- a/behave/_types.py
+++ b/behave/_types.py
@@ -1,6 +1,7 @@
 # -*- coding: UTF-8 -*-
 """Basic types (helper classes)."""
 
+import platform
 import sys
 import six
 if six.PY2:
@@ -55,8 +56,17 @@ class ExceptionUtil(object):
     @classmethod
     def describe(cls, exception, use_traceback=False, prefix=""):
         # -- NORMAL CASE:
-        text = u"{prefix}{0}: {1}\n".format(exception.__class__.__name__,
-                                            exception, prefix=prefix)
+        try:
+            text = u"{prefix}{0}: {1}\n".format(exception.__class__.__name__,
+                                                exception, prefix=prefix)
+        except UnicodeDecodeError as exc:
+            if platform.system() != 'Windows':
+                raise exc
+            # Avoid UnicodeDecodeError in Python 2 when 'exception' is a system
+            # error thrown by a Windows host configured in a non-ascii language
+            exc_message = str(exception).decode('cp1252', 'ignore')
+            text = u"{prefix}{0}: {1}\n".format(exception.__class__.__name__,
+                                                exc_message, prefix=prefix)
         if use_traceback:
             exc_traceback = cls.get_traceback(exception)
             if exc_traceback:

--- a/behave/log_capture.py
+++ b/behave/log_capture.py
@@ -96,7 +96,13 @@ class LoggingCapture(BufferingHandler):
         self.buffer = []
 
     def getvalue(self):
-        return '\n'.join(self.formatter.format(r) for r in self.buffer)
+        try:
+            return '\n'.join(self.formatter.format(r) for r in self.buffer)
+        except UnicodeDecodeError:
+            # Avoid UnicodeDecodeError in Python 2 when captured logs contain
+            # utf-8 characters
+            return '\n'.join(self.formatter.format(r).decode('utf-8', 'ignore')
+                             for r in self.buffer)
 
     def find_event(self, pattern):
         """Search through the buffer for a message that matches the given


### PR DESCRIPTION
Avoid UnicodeDecodeError in Python 2 in two cases:

* when captured logs contain utf-8 characters
* when a Windows host configured in a non-ascii language raises an exception with non-ascii chars
