### PR TITLE
Fix: issue 631: Outline variables not possible in table headings

### DIFF
--- a/behave/model.py
+++ b/behave/model.py
@@ -867,7 +867,8 @@ class ScenarioOutlineBuilder(object):
             new_step.text = cls.render_template(new_step.text, row)
         if new_step.table:
             for name, value in row.items():
-                new_step.table.headings = [cell.replace("<%s>" % name, value) for cell in new_step.table.headings]
+                for i, cell in enumerate(new_step.table.headings):
+                    new_step.table.headings[i] = cell.replace('<%s>' % name, value)
                 for row in new_step.table:
                     for i, cell in enumerate(row.cells):
                         row.cells[i] = cell.replace("<%s>" % name, value)

--- a/behave/model.py
+++ b/behave/model.py
@@ -867,6 +867,7 @@ class ScenarioOutlineBuilder(object):
             new_step.text = cls.render_template(new_step.text, row)
         if new_step.table:
             for name, value in row.items():
+                new_step.table.headings = [cell.replace("<%s>" % name, value) for cell in new_step.table.headings]
                 for row in new_step.table:
                     for i, cell in enumerate(row.cells):
                         row.cells[i] = cell.replace("<%s>" % name, value)

--- a/issue.features/issue0631.feature
+++ b/issue.features/issue0631.feature
@@ -1,5 +1,3 @@
-@issue
-@wip @not_working
 Feature: Issue #631 -- Scenario Outline variables not possible in table headings
 
   Background:
@@ -42,7 +40,6 @@ Feature: Issue #631 -- Scenario Outline variables not possible in table headings
       show_timings = false
       """
 
-  @xfail
   Scenario: Check Syndrome
     When  I run "behave -f plain features/"
     Then it should pass with:


### PR DESCRIPTION
Replace Outline Variable also in Table Headings.