### PR TITLE
fix and test cases for issue #675 (adding symlink feature files in odd dir structures)

### DIFF
--- a/behave/runner.py
+++ b/behave/runner.py
@@ -752,7 +752,7 @@ class Runner(ModelRunner):
         base_dir = new_base_dir
         self.config.base_dir = base_dir
 
-        for dirpath, dirnames, filenames in os.walk(base_dir):
+        for dirpath, dirnames, filenames in os.walk(base_dir, followlinks=True):
             if [fn for fn in filenames if fn.endswith(".feature")]:
                 break
         else:

--- a/behave/runner_util.py
+++ b/behave/runner_util.py
@@ -352,7 +352,7 @@ def collect_feature_locations(paths, strict=True):
     locations = []
     for path in paths:
         if os.path.isdir(path):
-            for dirpath, dirnames, filenames in os.walk(path):
+            for dirpath, dirnames, filenames in os.walk(path, followlinks=True):
                 dirnames.sort()
                 for filename in sorted(filenames):
                     if filename.endswith(".feature"):

--- a/issue.features/issue0675.feature
+++ b/issue.features/issue0675.feature
@@ -1,0 +1,38 @@
+@issue
+Feature: Issue #675 -- .feature files cannot be found within symlink directories
+
+
+  Background: setting up directory structure without symlink
+    Given a new working directory
+    And a file named "features/pass.feature" with:
+      """
+      Feature: Issue 675
+
+      Scenario: this too shall pass
+        Given this
+        When this
+        Then this
+      """
+    And a file named "second/steps/steps.py" with:
+      """
+      from behave import step
+
+      @step(u'this')
+      def step_impl(context):
+        pass
+      """
+
+  Scenario: failing case: feature symlink doesn't exist yet
+    When I run "behave -f plain second"
+    Then it should fail
+    And the command output should contain "ConfigError: No feature files in"
+
+  Scenario: add symlink to feature directory and expect pass
+    When I run "ln -s ../features second/features"
+    And I run "behave -f plain second"
+    Then it should pass with:
+      """
+      1 feature passed, 0 failed, 0 skipped
+      1 scenario passed, 0 failed, 0 skipped
+      3 steps passed, 0 failed, 0 skipped, 0 undefined
+      """

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -777,7 +777,7 @@ class FsMock(object):
         self.calls.append(("exists", path))
         return path in self.dirs or path in self.files
 
-    def walk(self, path, locations=None):
+    def walk(self, path, locations=None, followlinks=False):
         if locations is None:
             assert path in self.dirs, "%s not in %s" % (path, self.dirs)
             locations = []
@@ -1072,4 +1072,3 @@ class TestFeatureDirectoryLayout2(object):
                 assert_raises(ConfigError, r.setup_paths)
 
         ok_(("isdir", os.path.join(fs.base, "features", "steps")) in fs.calls)
-


### PR DESCRIPTION
This adds the ability for `behave` to find `.feature` files in more flexible directory structures when the common base supplies `steps` and `features` directories, and the `features` directory is a symlink outside of the directory structure.
```
./git-submodule
./working
./working/steps
./working/steps/steps.py
./working/features -> ../git-submodule

% behave ./working
ConfigError: No feature files in './working'
```

This supports workflows where the product specification `*.feature` files are segregated — say, in a git sub-module — from the test implementation `steps/*.py` files, related environment.py, and other implementation mess.  This allows for distinct GitHub PR practices for Product Design when creating new features in the BDD workflow.

Includes tests cases, one of which verifies as failing with behave 1.2.6 and passes with this patch.