### PR TITLE
class-based step definitions

### DIFF
--- a/behave/runner.py
+++ b/behave/runner.py
@@ -20,8 +20,8 @@ from behave.formatter._registry import make_formatters
 from behave.runner_util import \
     collect_feature_locations, parse_features, \
     exec_file, load_step_modules, PathManager
-#from behave.step_registry import registry as the_step_registry
 import behave.step_registry
+
 if six.PY2:
     # -- USE PYTHON3 BACKPORT: With unicode traceback support.
     import traceback2 as traceback
@@ -610,8 +610,6 @@ class ModelRunner(object):
         # pylint: disable=too-many-branches
         if not self.context:
             self.context = Context(self)
-        # if self.step_registry is None:
-        #     self.step_registry = the_step_registry
         if features is None:
             features = self.features
 

--- a/behave/runner.py
+++ b/behave/runner.py
@@ -20,7 +20,7 @@ from behave.formatter._registry import make_formatters
 from behave.runner_util import \
     collect_feature_locations, parse_features, \
     exec_file, load_step_modules, PathManager
-import behave.step_registry
+from behave.step_registry import registry as the_step_registry
 
 if six.PY2:
     # -- USE PYTHON3 BACKPORT: With unicode traceback support.
@@ -519,16 +519,12 @@ class ModelRunner(object):
         self.hooks = {}
         self.formatters = []
         self.undefined_steps = []
-        self._step_registry = step_registry
+        self.step_registry = step_registry
         self.capture_controller = CaptureController(config)
 
         self.context = None
         self.feature = None
         self.hook_failures = 0
-
-    @property
-    def step_registry(self):
-        return self._step_registry or behave.step_registry.registry
 
     # @property
     def _get_aborted(self):
@@ -610,6 +606,8 @@ class ModelRunner(object):
         # pylint: disable=too-many-branches
         if not self.context:
             self.context = Context(self)
+        if self.step_registry is None:
+            self.step_registry = the_step_registry
         if features is None:
             features = self.features
 

--- a/behave/runner.py
+++ b/behave/runner.py
@@ -20,8 +20,8 @@ from behave.formatter._registry import make_formatters
 from behave.runner_util import \
     collect_feature_locations, parse_features, \
     exec_file, load_step_modules, PathManager
-from behave.step_registry import registry as the_step_registry
-
+#from behave.step_registry import registry as the_step_registry
+import behave.step_registry
 if six.PY2:
     # -- USE PYTHON3 BACKPORT: With unicode traceback support.
     import traceback2 as traceback
@@ -519,12 +519,16 @@ class ModelRunner(object):
         self.hooks = {}
         self.formatters = []
         self.undefined_steps = []
-        self.step_registry = step_registry
+        self._step_registry = step_registry
         self.capture_controller = CaptureController(config)
 
         self.context = None
         self.feature = None
         self.hook_failures = 0
+
+    @property
+    def step_registry(self):
+        return self._step_registry or behave.step_registry.registry
 
     # @property
     def _get_aborted(self):
@@ -606,8 +610,8 @@ class ModelRunner(object):
         # pylint: disable=too-many-branches
         if not self.context:
             self.context = Context(self)
-        if self.step_registry is None:
-            self.step_registry = the_step_registry
+        # if self.step_registry is None:
+        #     self.step_registry = the_step_registry
         if features is None:
             features = self.features
 

--- a/behave/step_registry.py
+++ b/behave/step_registry.py
@@ -144,19 +144,19 @@ def local_step_registry(default_matcher=None):
     class LocalStepRegistry(object):
         _registry = LocalRegistry(matcher=default_matcher)
 
-        def register(self, registry=registry):
+        def register(self):
             """
-            add contained definitions to a registry
-            defaults to the global registry
+            adds contained definitions to the global registry
 
             This function also is responsible for updating functions in the registry with functions
             defined in subclasses
             """
+            from behave.runner import the_step_registry  # make sure we use same registry as normal definitions
             for step_type, steps in self._registry.steps.items():
                 for match_obj in steps:
                     if hasattr(self, match_obj.func.__name__):
                         match_obj.func = getattr(self, match_obj.func.__name__)
-                    registry.steps[step_type].append(match_obj)
+                    the_step_registry.steps[step_type].append(match_obj)
 
     for step_type in ("given", "when", "then", "step"):
         step_decorator = LocalStepRegistry._registry.make_decorator(step_type)

--- a/behave/step_registry.py
+++ b/behave/step_registry.py
@@ -146,7 +146,11 @@ def local_step_registry(default_matcher=None):
 
         def register(self, registry=registry):
             """
-            add contained definitions to a
+            add contained definitions to a registry
+            defaults to the global registry
+
+            This function also is responsible for updating functions in the registry with functions
+            defined in subclasses
             """
             for step_type, steps in self._registry.steps.items():
                 for match_obj in steps:

--- a/behave/step_registry.py
+++ b/behave/step_registry.py
@@ -133,6 +133,7 @@ class LocalRegistry(StepRegistry):
         self.steps[step_type].append(self.get_matcher(func, step_text, matcher))
 
     def make_decorator(self, step_type):
+        @staticmethod
         def decorator(step_text, matcher=None):
             def wrapper(func):
                 self.add_step_definition(step_type, step_text, func, matcher)
@@ -172,7 +173,8 @@ def local_step_registry(default_matcher=None):
             @functools.wraps(method)
             def newmethod(*args, **kwargs):
                 if args:
-                    context, *other_args = args
+                    context = args[0]
+                    other_args = args[1:]
                     if isinstance(context, Context):
                         cls._context = context
                         args = other_args

--- a/behave/step_registry.py
+++ b/behave/step_registry.py
@@ -34,10 +34,6 @@ class StepRegistry(object):
         }
 
     @staticmethod
-    def get_matcher(func, step_text):
-        return get_matcher(func, step_text)
-
-    @staticmethod
     def same_step_definition(step, other_pattern, other_location):
         return (step.pattern == other_pattern and
                 step.location == other_location and
@@ -60,7 +56,7 @@ class StepRegistry(object):
                 existing_step = existing.describe()
                 existing_step += u" at %s" % existing.location
                 raise AmbiguousStep(message % (new_step, existing_step))
-        step_definitions.append(self.get_matcher(func, step_text))
+        step_definitions.append(get_matcher(func, step_text))
 
     def find_step_definition(self, step):
         candidates = self.steps[step.step_type]

--- a/features/class_steps.feature
+++ b/features/class_steps.feature
@@ -1,58 +1,79 @@
-Feature: Execute Steps within a Step Function (Nested Steps)
+Feature: Execute class-based steps with inheritance (Nested Steps)
 
     As a tester
     I want to reuse existing steps as class methods
-    And I want to extend those class methods with subclasses
     So that I can comply with the the DRY principle.
 
-  Scenario: Execute a number of simple steps (GOOD CASE)
+  Background:
     Given a new working directory
-    And   a file named "features/steps/steps.py" with:
+    And   a file named "features/steps/base_steps.py" with:
+    """
+    from behave.step_registry import local_step_registry
+
+    Base = local_step_registry()
+    class SomeSteps(Base):
+        @Base.given(u'I go to the supermarket')
+        def step_given_I_go_to_the_supermarket(self):
+            self.context.shopping_cart = {}
+
+        @Base.when(u'I buy {amount:n} {item:w}')
+        def step_when_I_buy(self, amount, item):
+            assert amount >= 0
+            if not item in self.context.shopping_cart:
+                self.context.shopping_cart[item] = 0
+            self.context.shopping_cart[item] += amount
+
+        @Base.when(u'I buy the usual things')
+        def step_when_I_buy_the_usual_things(self):
+            self.step_when_I_buy(2, 'apples')
+            self.step_when_I_buy(3, 'bananas')
+
+        @Base.then(u'I have {amount:n} {item:w}')
+        def step_then_I_have(self, amount, item):
+            actual = self.context.shopping_cart.get(item, 0)
+            assert amount == actual
+    """
+
+  Scenario: Simply execute some class-based definitions
+    Given   a file named "features/steps/steps.py" with:
       """
-      from behave.step_registry import local_step_registry
-
-      Base = local_step_registry()
-      class SomeSteps(Base):
-          @Base.given(u'I go to the supermarket')
-          def step_given_I_go_to_the_supermarket(self):
-              self.context.shopping_cart = {}
-
-          @Base.when(u'I buy {amount:n} {item:w}')
-          def step_when_I_buy(self, amount, item):
-              assert amount >= 0
-              if not item in self.context.shopping_cart:
-                  self.context.shopping_cart[item] = 0
-              self.context.shopping_cart[item] += amount
-
-          @Base.when(u'I buy the usual things')
-          def step_when_I_buy_the_usual_things(self):
-              self.step_when_I_buy(2, 'apples')
-              self.step_when_I_buy(3, 'bananas')
-
-          @Base.then(u'I have {amount:n} {item:w}')
-          def step_then_I_have(self, amount, item):
-              actual = self.context.shopping_cart.get(item, 0)
-              assert amount == actual
-
-
-      class ExtendedSteps(SomeSteps):
-          usual_things = {
-              'apples': 2,
-              'bananas': 3
-          }
-          def step_when_I_buy_the_usual_things(self):
-              for item, quantity in self.usual_things.items():
-                  self.step_when_I_buy(quantity, item)
-
-      class MoreExtendedSteps(ExtendedSteps):
-          usual_things = {
-              'apples': 1,
-              'bananas': 1
-          }
-
-      MoreExtendedSteps().register()
-
+      from base_steps import SomeSteps
+      SomeSteps().register()
       """
+    And   a file named "features/use_class_steps.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given I go to the supermarket
+          When  I buy the usual things
+          Then  I have 2 apples
+          And   I have 3 bananas
+      """
+    When I run "behave -f plain features/use_class_steps.feature"
+    Then it should pass with:
+      """
+      1 feature passed, 0 failed, 0 skipped
+      1 scenario passed, 0 failed, 0 skipped
+      4 steps passed, 0 failed, 0 skipped, 0 undefined
+      """
+
+  Scenario: Extend a set of class-based steps
+    Given a file named "features/steps/steps.py" with:
+    """
+    from base_steps import SomeSteps
+
+    class ExtendedSteps(SomeSteps):
+        usual_things = {
+            'apples': 1,
+            'bananas': 1
+        }
+        def step_when_I_buy_the_usual_things(self):
+            for item, quantity in self.usual_things.items():
+                self.step_when_I_buy(quantity, item)
+
+    ExtendedSteps().register()
+
+    """
     And   a file named "features/use_class_steps.feature" with:
       """
       Feature:
@@ -70,3 +91,52 @@ Feature: Execute Steps within a Step Function (Nested Steps)
       4 steps passed, 0 failed, 0 skipped, 0 undefined
       """
 
+  Scenario: Make additional steps in a subclass (with custom matcher)
+    Given a file named "features/steps/steps.py" with:
+    """
+    from base_steps import SomeSteps
+    from behave.matchers import RegexMatcher
+    class ExtendedSteps(SomeSteps):
+        usual_things = {
+            'apples': 2,
+            'bananas': 4
+        }
+        def step_when_I_buy_the_usual_things(self):
+            for item, quantity in self.usual_things.items():
+                self.step_when_I_buy(quantity, item)
+
+        @SomeSteps.when(u'I (double|halve) my item quantities', matcher=RegexMatcher)
+        def multiply_quantity(self, by_amount):
+            cart = self.context.shopping_cart
+            if by_amount == 'double':
+                multiple = 2
+            else:
+                multiple = 0.5
+            for item in cart:
+                current_quantity = cart[item]
+                cart[item] *= multiple
+
+    ExtendedSteps().register()
+    """
+    And   a file named "features/use_class_steps.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given I go to the supermarket
+          When  I buy the usual things
+          Then  I have 2 apples
+          And   I have 4 bananas
+          When  I double my item quantities
+          Then  I have 4 apples
+          And   I have 8 bananas
+          When  I halve my item quantities
+          Then  I have 2 apples
+          And   I have 4 bananas
+      """
+    When I run "behave -f plain features/use_class_steps.feature"
+    Then it should pass with:
+      """
+      1 feature passed, 0 failed, 0 skipped
+      1 scenario passed, 0 failed, 0 skipped
+      10 steps passed, 0 failed, 0 skipped, 0 undefined
+      """

--- a/features/class_steps.feature
+++ b/features/class_steps.feature
@@ -1,0 +1,72 @@
+Feature: Execute Steps within a Step Function (Nested Steps)
+
+    As a tester
+    I want to reuse existing steps as class methods
+    And I want to extend those class methods with subclasses
+    So that I can comply with the the DRY principle.
+
+  Scenario: Execute a number of simple steps (GOOD CASE)
+    Given a new working directory
+    And   a file named "features/steps/steps.py" with:
+      """
+      from behave.step_registry import local_step_registry
+
+      Base = local_step_registry()
+      class SomeSteps(Base):
+          @Base.given(u'I go to the supermarket')
+          def step_given_I_go_to_the_supermarket(self):
+              self.context.shopping_cart = {}
+
+          @Base.when(u'I buy {amount:n} {item:w}')
+          def step_when_I_buy(self, amount, item):
+              assert amount >= 0
+              if not item in self.context.shopping_cart:
+                  self.context.shopping_cart[item] = 0
+              self.context.shopping_cart[item] += amount
+
+          @Base.when(u'I buy the usual things')
+          def step_when_I_buy_the_usual_things(self):
+              self.step_when_I_buy(2, 'apples')
+              self.step_when_I_buy(3, 'bananas')
+
+          @Base.then(u'I have {amount:n} {item:w}')
+          def step_then_I_have(self, amount, item):
+              actual = self.context.shopping_cart.get(item, 0)
+              assert amount == actual
+
+
+      class ExtendedSteps(SomeSteps):
+          usual_things = {
+              'apples': 2,
+              'bananas': 3
+          }
+          def step_when_I_buy_the_usual_things(self):
+              for item, quantity in self.usual_things.items():
+                  self.step_when_I_buy(quantity, item)
+
+      class MoreExtendedSteps(ExtendedSteps):
+          usual_things = {
+              'apples': 1,
+              'bananas': 1
+          }
+
+      MoreExtendedSteps().register()
+
+      """
+    And   a file named "features/use_class_steps.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given I go to the supermarket
+          When  I buy the usual things
+          Then  I have 1 apples
+          And   I have 1 bananas
+      """
+    When I run "behave -f plain features/use_class_steps.feature"
+    Then it should pass with:
+      """
+      1 feature passed, 0 failed, 0 skipped
+      1 scenario passed, 0 failed, 0 skipped
+      4 steps passed, 0 failed, 0 skipped, 0 undefined
+      """
+


### PR DESCRIPTION
This PR aims introduces class-based step definitions as a feature to `behave`. The primary goal of this feature is to introduce a beautiful way of extending upon existing code in step definitions; beyond what it already available with `context.execute_steps`. It is primarily aimed at developers of reusable step libraries, but has clear benefits for everyone.

This feature would provide the following:

- ability to define step definitions as classes
- ability to extend steps from your own classes (or perhaps classes provided by other libraries/packages)
- ability to define a matcher per-method without changing global state of the 'current matcher'
- wraps methods to transform `context` into an attribute (`self.context`), so it's not necessary to have each method use `context` as first parameter in the signature. Works with default runner.


These basics are covered in the added test (`features/class_steps.feature`). 

Additionally, I believe class-based definitions would make it easy to introduce a lot of other niceties. For example, to get assertion matchers from the stdlib `unittest` module (e.g. `self.assertEquals`) one only has to use `unittest.TestCase` as a mixin to the class: 
(extending on example in `features/class_steps.feature`)
```
import unittest
from base_steps import SomeSteps

class ExtendedSteps(SomeSteps, unittest.TestCase):
    def step_then_I_have(self, amount, item):
        actual = self.context.shopping_cart.get(item, 0)
        self.assertEquals(actual, amount, 
            f'Expected {amount} of "{item}", but cart had {actual} of "{item}"'
        )

ExtendedSteps().register()  # register local definitions to the global step registry
```

This and many other integrations are made possible and simple by class-based definitions. I hope to provide some more compelling examples, but I believe at a minimum, this change will help users make step implementations that are more flexible and DRY compliant.


Notes:

- There's definitely refactoring potential in `LocalRegistry` class, if some elements are moved to the `StepRegistry` class -- I chose to leave `StepRegistry` alone for the sake of making the PR more palatable to merge in as an experimental, purely opt-in, feature

- per-step matchers are more or less an independent feature: they could easily be adapted to existing StepRegistry/decorators, with or without the rest of the changes.

- current implementation only considers the default behave runner; could probably be adapted to be more flexible with other runners.

Related issue: #630 

Would love to hear thoughts on this. If this has a remote interest in being added to `behave`, I'll be happy to write end-user documentation for this feature.