### PR TITLE
Ads "Ukoliko" as Croatian "Given" alternative

### DIFF
--- a/bin/i18n.yml
+++ b/bin/i18n.yml
@@ -303,7 +303,7 @@
   scenario: Scenarij
   scenario_outline: Skica|Koncept
   examples: Primjeri|Scenariji
-  given: "*|Zadan|Zadani|Zadano"
+  given: "*|Zadan|Zadani|Zadano|Ukoliko"
   when: "*|Kada|Kad"
   then: "*|Onda"
   and: "*|I"


### PR DESCRIPTION
"Ukoliko" expresses the givens for the test linguistically in more natural way.