### PR TITLE
Fix "Bleading edge" typo on install.rst

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -41,7 +41,7 @@ enter the newly created directory "behave-<version>" and run::
 Using the Github Repository
 ---------------------------
 
-:Category: Bleading edge
+:Category: Bleeding edge
 :Precondition: :pypi:`pip` is installed
 
 Run the following command


### PR DESCRIPTION
Nothing critical, though... I've just noticed this while glancing through the tutorial. 🙂