### PR TITLE
Setup log file - add filename handling in setup_logging()

### DIFF
--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -557,6 +557,7 @@ class Configuration(object):
         self.junit = None
         self.logging_format = None
         self.logging_datefmt = None
+        self.logging_filename = None
         self.name = None
         self.scope = None
         self.steps_catalog = None
@@ -739,7 +740,8 @@ class Configuration(object):
             # pylint: disable=no-member
             format_ = kwargs.pop("format", self.logging_format)
             datefmt = kwargs.pop("datefmt", self.logging_datefmt)
-            logging.basicConfig(format=format_, datefmt=datefmt, **kwargs)
+            filename = kwargs.pop("filename", self.logging_filename)
+            logging.basicConfig(format=format_, datefmt=datefmt, filename=filename, **kwargs)
         # -- ENSURE: Default log level is set
         #    (even if logging subsystem is already configured).
         logging.getLogger().setLevel(level)


### PR DESCRIPTION
Hello,

last weeks I faced some issues with setting up logging in our tests and I noticed, that `behave` not allow us to set logging to file feature. We need to work around it by manually specify `logging.basicCofnig()` by our own and use `logging`, but after checking how `behave` is handling it on his site, I saw that is using this same.

This little feature allows us to use and setup log file for our tests execution logs, but it's not necessary, so it had **backward compatibility**.

Also, where I could find some contribution guide? I couldn't get any information about the PR template, necessary checklists etc.

Best,
Marcin