### PR TITLE
Store error and logging separately in the model code so formatters can access it

### DIFF
--- a/behave/model.py
+++ b/behave/model.py
@@ -1660,7 +1660,7 @@ class Step(BasicStatement, Replayable):
                 self.captured = runner.capture_controller.captured
                 error2 = self.captured.make_report()
                 if error2:
-                    error += "\n" + error2
+                    error += "\n" + error2 + "\n\n" + error
             self.error_message = error
             keep_going = False
         elif store_captured and capture:

--- a/behave/model.py
+++ b/behave/model.py
@@ -1655,6 +1655,7 @@ class Step(BasicStatement, Replayable):
         store_captured = self.status == Status.failed or store_captured_always
         if self.status == Status.failed:
             assert isinstance(error, six.text_type)
+            self.error_message1 = error
             if capture:
                 # -- CAPTURE-ONLY: Non-nested step failures.
                 self.captured = runner.capture_controller.captured
@@ -1662,6 +1663,7 @@ class Step(BasicStatement, Replayable):
                 if error2:
                     error += "\n" + error2 + "\n\n" + error
             self.error_message = error
+            self.error_message2 = error2
             keep_going = False
         elif store_captured and capture:
             self.captured = runner.capture_controller.captured

--- a/behave/model.py
+++ b/behave/model.py
@@ -1661,7 +1661,7 @@ class Step(BasicStatement, Replayable):
                 self.captured = runner.capture_controller.captured
                 error2 = self.captured.make_report()
                 if error2:
-                    error += "\n" + error2 + "\n\n" + error
+                    error += "\n" + error2
             self.error_message = error
             self.error_message2 = error2
             keep_going = False

--- a/behave/model.py
+++ b/behave/model.py
@@ -1656,14 +1656,15 @@ class Step(BasicStatement, Replayable):
         if self.status == Status.failed:
             assert isinstance(error, six.text_type)
             self.error_message1 = error
+            self.error_message2 = None
             if capture:
                 # -- CAPTURE-ONLY: Non-nested step failures.
                 self.captured = runner.capture_controller.captured
                 error2 = self.captured.make_report()
                 if error2:
                     error += "\n" + error2
+                    self.error_message2 = error2
             self.error_message = error
-            self.error_message2 = error2
             keep_going = False
         elif store_captured and capture:
             self.captured = runner.capture_controller.captured

--- a/features/logcapture.feature
+++ b/features/logcapture.feature
@@ -119,8 +119,6 @@ Feature: Capture log output
             ERROR:foo:Hello Bob
             WARNING:foo.bar:Hello Charly
             INFO:bar:Hello Dora
-
-            Assertion Failed: EXPECT: Failing step
             """
         And the command output should contain the following log records:
             | category | level   | message |

--- a/features/logcapture.feature
+++ b/features/logcapture.feature
@@ -119,6 +119,8 @@ Feature: Capture log output
             ERROR:foo:Hello Bob
             WARNING:foo.bar:Hello Charly
             INFO:bar:Hello Dora
+
+            Assertion Failed: EXPECT: Failing step
             """
         And the command output should contain the following log records:
             | category | level   | message |


### PR DESCRIPTION
When debugging failed tests, if the captured logging is verbose, you can easily lose sight of the error since it is printed above the captured logs. I would like it if the error were reprinted at the bottom of the captured logs. I would implement this as a formatter, but as far as I'm aware this can only be done as part of the model code.

I have implemented the change that would store the two error types separately so a formatter would be able to use them as it saw fit.