### PR TITLE
Fixed a bug where option --no-timings is not working on JSON report

### DIFF
--- a/behave/formatter/json.py
+++ b/behave/formatter/json.py
@@ -35,6 +35,7 @@ class JSONFormatter(Formatter):
         super(JSONFormatter, self).__init__(stream_opener, config)
         # -- ENSURE: Output stream is open.
         self.stream = self.open()
+        self.show_timings = config.show_timings
         self.feature_count = 0
         self.current_feature = None
         self.current_feature_data = None
@@ -154,10 +155,10 @@ class JSONFormatter(Formatter):
 
     def result(self, step):
         steps = self.current_feature_element["steps"]
-        steps[self._step_index]["result"] = {
-            "status": step.status.name,
-            "duration": step.duration,
-        }
+        result = {"status": step.status.name}
+        if self.show_timings:
+            result["duration"] = step.duration
+        steps[self._step_index]["result"] = result
         if step.error_message and step.status == Status.failed:
             # -- OPTIONAL: Provided for failed steps.
             error_message = step.error_message

--- a/features/formatter.json.feature
+++ b/features/formatter.json.feature
@@ -309,6 +309,71 @@ Feature: JSON Formatter
       But note that "both matched arguments.values are provided as string"
 
 
+    Scenario: Use JSON formatter with --no-timings option
+      Given a file named "features/scenario_with_steps_no_timings.feature" with:
+            """
+            Feature:
+              Scenario: Simple scenario with --no-timings options
+                  When a step passes
+                  Then a step passes
+            """
+        When I run "behave -f json.pretty --no-timings features/scenario_with_steps_no_timings.feature"
+        Then it should pass with:
+            """
+            1 feature passed, 0 failed, 0 skipped
+            1 scenario passed, 0 failed, 0 skipped
+            """
+        And the command output should contain:
+            """
+            [
+            {
+              "elements": [
+                {
+                  "keyword": "Scenario",
+                  "location": "features/scenario_with_steps_no_timings.feature:2",
+                  "name": "Simple scenario with --no-timings options",
+                  "status": "passed",
+                  "steps": [
+                    {
+                      "keyword": "When",
+                      "location": "features/scenario_with_steps_no_timings.feature:3",
+                      "match": {
+                        "arguments": [],
+                        "location": "features/steps/steps.py:3"
+                      },
+                      "name": "a step passes",
+                      "result": {
+                        "status": "passed"
+                      },
+                      "step_type": "when"
+                    },
+                    {
+                      "keyword": "Then",
+                      "location": "features/scenario_with_steps_no_timings.feature:4",
+                      "match": {
+                        "arguments": [],
+                        "location": "features/steps/steps.py:3"
+                      },
+                      "name": "a step passes",
+                      "result": {
+                        "status": "passed"
+                      },
+                      "step_type": "then"
+                    }
+                  ],
+                  "tags": [],
+                  "type": "scenario"
+                }
+              ],
+              "keyword": "Feature",
+              "location": "features/scenario_with_steps_no_timings.feature:1",
+              "name": "",
+              "status": "passed",
+              "tags": []
+            }
+            ]
+            """
+
     @xfail
     @regression_problem.with_duration
     Scenario: Use JSON formatter with feature and one scenario with steps


### PR DESCRIPTION
#739 JSON Formatter: --no-timings/-T option is not working:
https://github.com/behave/behave/issues/739