### PR TITLE
Adds the ability to use a custom runner in the behave command

### DIFF
--- a/behave/__main__.py
+++ b/behave/__main__.py
@@ -215,7 +215,7 @@ def main(args=None):
     :return: 0, if successful. Non-zero, in case of errors/failures.
     """
     config = Configuration(args)
-    return run_behave(config)
+    return run_behave(config, runner_class=config.runner_class)
 
 
 if __name__ == "__main__":

--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -8,6 +8,7 @@ import re
 import sys
 import shlex
 import six
+from importlib import import_module
 from six.moves import configparser
 
 from behave.model import ScenarioOutline
@@ -65,6 +66,16 @@ class LogLevel(object):
 # -----------------------------------------------------------------------------
 # CONFIGURATION SCHEMA:
 # -----------------------------------------------------------------------------
+
+def valid_python_module(path):
+    try:
+        module_path, class_name = path.rsplit('.', 1)
+        module = import_module(module_path)
+        return getattr(module, class_name)
+    except (ValueError, AttributeError, ImportError):
+        raise argparse.ArgumentTypeError("No module named '%s' was found." % path)
+
+
 options = [
     (("-c", "--no-color"),
      dict(action="store_false", dest="color",
@@ -111,6 +122,11 @@ options = [
      dict(metavar="PATH", dest="junit_directory",
           default="reports",
           help="""Directory in which to store JUnit reports.""")),
+    
+    (("--runner-class",),
+     dict(action="store",
+          default="behave.runner.Runner", type=valid_python_module,
+          help="Tells Behave to use a specific runner. (default: %(default)s)")),
 
     ((),  # -- CONFIGFILE only
      dict(dest="default_format",

--- a/docs/behave.rst
+++ b/docs/behave.rst
@@ -55,6 +55,11 @@ You may see the same information presented below at any time using ``behave
 
     Directory in which to store JUnit reports.
 
+.. option:: --runner-class
+
+    This allows you to use your own custom runner. The default is 
+    ``behave.runner.Runner``.
+
 .. option:: -f, --format
 
     Specify a formatter. If none is specified the default formatter is

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -5,6 +5,7 @@ import six
 import pytest
 from behave import configuration
 from behave.configuration import Configuration, UserData
+from behave.runner import Runner as BaseRunner
 from unittest import TestCase
 
 
@@ -35,6 +36,10 @@ if sys.platform.startswith("win"):
     if six.PY2:
         ROOTDIR_PREFIX_DEFAULT = ROOTDIR_PREFIX_DEFAULT.lower()
     ROOTDIR_PREFIX = os.environ.get("BEHAVE_ROOTDIR_PREFIX", ROOTDIR_PREFIX_DEFAULT)
+
+
+class CustomTestRunner(BaseRunner):
+    """Custom, dummy runner"""
 
 
 class TestConfiguration(object):
@@ -91,6 +96,20 @@ class TestConfiguration(object):
         assert "STAGE2_steps" == config.steps_dir
         assert "STAGE2_environment.py" == config.environment_file
         del os.environ["BEHAVE_STAGE"]
+
+    def test_settings_runner_class(self, capsys):
+        config = Configuration("")
+        assert BaseRunner == config.runner_class
+
+    def test_settings_runner_class_custom(self, capsys):
+        config = Configuration(["--runner-class=tests.unit.test_configuration.CustomTestRunner"])
+        assert CustomTestRunner == config.runner_class
+
+    def test_settings_runner_class_invalid(self, capsys):
+        with pytest.raises(SystemExit):
+            Configuration(["--runner-class=does.not.exist.Runner"])
+        captured = capsys.readouterr()
+        assert "No module named 'does.not.exist.Runner' was found." in captured.err
 
 
 class TestConfigurationUserData(TestCase):


### PR DESCRIPTION
This all started here: https://github.com/behave/behave-django/pull/100

I'm making a rather large test migration from Aloe to Behave. 

```
$ find . -name *.feature | xargs cat | wc -l
  157533
```

Currently, all our tests are inside our apps like so: (py + feature files all in the same folder inside EACH app)

```
<project>/<app>/features
                        /__init__.py
                        /sometest.feature
                        /sometest_steps.py
                        /steps.py
```

I do not want to make this migration any more painful than it needs to be, so my plan is to modify `behave.runner.Runner` ~`BehaviorDrivenTestRunner`~ to find my tests in the appropriate place. Right now there is no way for me to modify the way this works. ~This is the exact reason django exposes `--testrunner` and i was very surprised this was something overlooked in this project.~

Making this modification works great: `./manage.py behave --behave-runner myproject.runner.Runner`

```python
import os

from behave.runner import Runner as BaseRunner, load_step_modules
from django.conf import settings


class Runner(BaseRunner):

    def load_step_definitions(self, extra_step_paths=None):
        step_paths = [] + list(extra_step_paths or [])
        for root, dirs, _ in os.walk(settings.BASE_DIR):
            for dir in dirs:
                if dir.endswith('features'):
                    full_path = os.path.join(root, dir)
                    step_paths.append(full_path)

        load_step_modules(step_paths)
```