### PR TITLE
Add context.attach method to embed files in JSON reports

### DIFF
--- a/behave/formatter/json.py
+++ b/behave/formatter/json.py
@@ -168,10 +168,12 @@ class JSONFormatter(Formatter):
         self._step_index += 1
 
     def embedding(self, mime_type, data):
-        step = self.current_feature_element["steps"][-1]
+        step = self.current_feature_element["steps"][self._step_index]
+        if "embeddings" not in step:
+            step["embeddings"] = []
         step["embeddings"].append({
             "mime_type": mime_type,
-            "data": base64.b64encode(data).replace("\n", ""),
+            "data": base64.b64encode(data).decode(self.stream.encoding or "utf-8"),
         })
 
     def eof(self):

--- a/behave/runner.py
+++ b/behave/runner.py
@@ -475,6 +475,17 @@ class Context(object):
             # -- AVOID DUPLICATES:
             current_frame["@cleanups"].append(internal_cleanup_func)
 
+    def attach(self, mime_type, data):
+        """Embeds data (e.g. a screenshot) in reports for all
+        formatters that support it, such as the JSON formatter.
+
+        :param mime_type:       MIME type of the binary data.
+        :param data:            Bytes-like object to embed.
+        """
+        is_compatible = lambda f: hasattr(f, "embedding")
+        for formatter in filter(is_compatible, self._runner.formatters):
+            formatter.embedding(mime_type, data)
+
 
 @contextlib.contextmanager
 def use_context_with_mode(context, mode):

--- a/docs/formatters.rst
+++ b/docs/formatters.rst
@@ -116,3 +116,21 @@ teamcity       :pypi:`behave-teamcity`, a formatter for Jetbrains TeamCity CI te
     [behave.formatters]
     allure   = allure_behave.formatter:AllureFormatter
     teamcity = behave_teamcity:TeamcityFormatter
+
+
+Embedding data (e.g. screenshots) in reports
+------------------------------------------------------------------------------
+
+You can embed data in reports with the :class:`~behave.runner.Context` method
+:func:`~behave.runner.Context.attach`, if you have configured a formatter that
+supports it. Currently only the JSON formatter supports embedding data.
+
+For example:
+
+.. code-block:: python
+
+    @when(u'I open the Google webpage')
+    def step_impl(context):
+        context.browser.get('http://www.google.com')
+        img = context.browser.get_full_page_screenshot_as_png()
+        context.attach("image/png", img)

--- a/features/formatter.json.feature
+++ b/features/formatter.json.feature
@@ -309,6 +309,48 @@ Feature: JSON Formatter
       But note that "both matched arguments.values are provided as string"
 
 
+    Scenario: Use JSON formatter and embed binary data in report from two steps
+      Given a file named "features/json_embeddings.feature" with:
+          """
+          Feature:
+            Scenario: Use embeddings
+                Given "foobar" as plain text
+                And "red" as plain text
+          """
+      And a file named "features/steps/json_embeddings_steps.py" with:
+          """
+          from behave import step
+
+          @step('"{data}" as plain text')
+          def step_string(context, data):
+              context.attach("text/plain", data.encode("utf-8"))
+          """
+      When I run "behave -f json.pretty features/json_embeddings.feature"
+      Then it should pass with:
+          """
+          1 feature passed, 0 failed, 0 skipped
+          1 scenario passed, 0 failed, 0 skipped
+          """
+      And the command output should contain:
+          """
+                    "embeddings": [
+                      {
+                        "data": "Zm9vYmFy",
+                        "mime_type": "text/plain"
+                      }
+                    ],
+          """
+      And the command output should contain:
+          """
+                    "embeddings": [
+                      {
+                        "data": "cmVk",
+                        "mime_type": "text/plain"
+                      }
+                    ],
+          """
+
+
     @xfail
     @regression_problem.with_duration
     Scenario: Use JSON formatter with feature and one scenario with steps


### PR DESCRIPTION
See the test for example.

I attempted to add it to the docs but I'm not sure if my changes are appropriate.

Closes #791

(Travis CI passes: https://travis-ci.org/github/behave/behave/builds/667662398)