### PR TITLE
Allow Context to be used in step names and text

### DIFF
--- a/behave/model.py
+++ b/behave/model.py
@@ -1767,18 +1767,18 @@ class Step(BasicStatement, Replayable):
         # self.hook_failed = False
         self.reset()
 
-        flat_context = runner.context.as_flat()
+        render_params = {}
 
-        for k, v in list(flat_context.items()):
+        for k, v in runner.context.as_flat().items():
             try:
-                flat_context[k] = str(v)
+                render_params['ctx:' + k] = str(v)
             except:
-                del flat_context[k]
+                pass
 
-        self.name = ScenarioOutlineBuilder.render_template(self.name, params=flat_context)
+        self.name = ScenarioOutlineBuilder.render_template(self.name, params=render_params)
 
         if self.text:
-            self.text = ScenarioOutlineBuilder.render_template(self.text, params=flat_context)
+            self.text = ScenarioOutlineBuilder.render_template(self.text, params=render_params)
 
         match = runner.step_registry.find_match(self)
         if match is None:

--- a/behave/model.py
+++ b/behave/model.py
@@ -1767,6 +1767,19 @@ class Step(BasicStatement, Replayable):
         # self.hook_failed = False
         self.reset()
 
+        flat_context = runner.context.as_flat()
+
+        for k in list(flat_context.keys()):
+            try:
+                flat_context[k] = str(k)
+            except:
+                del flat_context[k]
+
+        self.name = ScenarioOutlineBuilder.render_template(self.name, params=flat_context)
+
+        if self.text:
+            self.text = ScenarioOutlineBuilder.render_template(self.text, params=flat_context)
+
         match = runner.step_registry.find_match(self)
         if match is None:
             runner.undefined_steps.append(self)

--- a/behave/model.py
+++ b/behave/model.py
@@ -1769,9 +1769,9 @@ class Step(BasicStatement, Replayable):
 
         flat_context = runner.context.as_flat()
 
-        for k in list(flat_context.keys()):
+        for k, v in list(flat_context.items()):
             try:
-                flat_context[k] = str(k)
+                flat_context[k] = str(v)
             except:
                 del flat_context[k]
 

--- a/behave/runner.py
+++ b/behave/runner.py
@@ -324,6 +324,15 @@ class Context(object):
             else:
                 print(prefix + repr(frame))
 
+    def as_flat(self):
+        variables = {}
+
+        for frame in self._stack:
+            for k, v in frame.items():
+                variables[k] = str(v)
+
+        return variables
+
     def __getattr__(self, attr):
         if attr[0] == "_":
             try:

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -433,6 +433,31 @@ The *context* variable in all cases is an instance of
 
 .. _docid.tutorial.environmental-controls:
 
+Using Context data in steps
+---------------------------
+
+Like shown above, you can use the data in "context" to pass data between steps.
+Variables stored there can also be used in a scenario like so:
+
+.. code-block:: python
+
+    @given('I request a new widget for an account via SOAP')
+    def step_impl(context):
+        client = Client("http://127.0.0.1:8000/soap/")
+        response = client.Allocate(first='Firstname', last='Lastname')
+        context.widget_id = response['id']
+
+    @then('I delete the widget with ID "{id}"')
+    def step_impl(context, id):
+        client = Client("http://127.0.0.1:8000/soap/")
+        client.delete(id)
+
+.. code-block:: gherkin
+
+  Scenario: request and delete widget
+    Given I request a new widget for an account via SOAP
+    When I delete the widget with ID "<widget_id>"
+
 Environmental Controls
 ======================
 

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -461,6 +461,7 @@ class TestStepRun(unittest.TestCase):
         self.config = self.runner.config = Mock()
         self.config.outputs = [None]
         self.context = self.runner.context = Mock()
+        self.context.as_flat = lambda: {'thing': 'wombats'}
         print("context is %s" % self.context)
         self.formatters = self.runner.formatters = [Mock()]
         self.stdout_capture = self.capture_controller.stdout_capture = Mock()
@@ -660,6 +661,15 @@ class TestStepRun(unittest.TestCase):
         assert not step.run(self.runner)
         assert "Captured logging:" in step.error_message
         assert "toads" in step.error_message
+
+    def test_run_replaces_variables(self):
+        self.runner.step_registry.find_match.return_value = Mock()
+
+        step = Step("foo.feature", 17, u"Given", "given", u"some <thing> name", u"some <thing> text")
+        assert step.run(self.runner)
+
+        assert step.name == "some wombats name"
+        assert step.text == "some wombats text"
 
 
 class TestTableModel(unittest.TestCase):

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -671,6 +671,14 @@ class TestStepRun(unittest.TestCase):
         assert step.name == "some wombats name"
         assert step.text == "some wombats text"
 
+    def test_run_fails_on_missing_variables(self):
+        self.runner.step_registry.find_match.return_value = Mock()
+
+        step = Step("foo.feature", 17, u"Given", "given", u"some <unknown_thing> name", u"")
+        assert step.run(self.runner)
+
+        assert step.name == "some <unknown_thing> name"
+
 
 class TestTableModel(unittest.TestCase):
     # pylint: disable=invalid-name

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -665,7 +665,7 @@ class TestStepRun(unittest.TestCase):
     def test_run_replaces_variables(self):
         self.runner.step_registry.find_match.return_value = Mock()
 
-        step = Step("foo.feature", 17, u"Given", "given", u"some <thing> name", u"some <thing> text")
+        step = Step("foo.feature", 17, u"Given", "given", u"some <ctx:thing> name", u"some <ctx:thing> text")
         assert step.run(self.runner)
 
         assert step.name == "some wombats name"
@@ -674,10 +674,10 @@ class TestStepRun(unittest.TestCase):
     def test_run_fails_on_missing_variables(self):
         self.runner.step_registry.find_match.return_value = Mock()
 
-        step = Step("foo.feature", 17, u"Given", "given", u"some <unknown_thing> name", u"")
+        step = Step("foo.feature", 17, u"Given", "given", u"some <ctx:unknown_thing> name", u"")
         assert step.run(self.runner)
 
-        assert step.name == "some <unknown_thing> name"
+        assert step.name == "some <ctx:unknown_thing> name"
 
 
 class TestTableModel(unittest.TestCase):

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -140,6 +140,20 @@ class TestContext(unittest.TestCase):
         assert self.context.other_thing == "more stuff"
         assert self.context.third_thing == "wombats"
 
+    def test_as_flat_returns_flattened_context(self):
+        self.context.thing = "stuff"
+
+        flat = self.context.as_flat()
+        assert flat["thing"] == "stuff"
+
+        self.context.thing = "new stuff"
+        self.context.other_thing = "wombats"
+        self.context._push()
+
+        flat = self.context.as_flat()
+        assert flat["thing"] == "new stuff"
+        assert flat["other_thing"] == "wombats"
+
     def test_attributes_set_at_lower_level_not_visible_at_upper_level(self):
         self.context.thing = "stuff"
 


### PR DESCRIPTION
Insert the data inside context into step names and texts, so they can be used like variables from `Scenario Outlines`. Refer to the included docs for details.

If you'd like anything implemented differently, just tell me. I am happy to adapt this to your liking.