### PR TITLE
Ensure that formatter.eof() is called, to ensure that current feature…

### DIFF
--- a/behave/runner.py
+++ b/behave/runner.py
@@ -669,6 +669,7 @@ class ModelRunner(object):
         if self.aborted:
             print("\nABORTED: By user.")
         for formatter in self.formatters:
+            formatter.eof()
             formatter.close()
         for reporter in self.config.reporters:
             reporter.end()


### PR DESCRIPTION
… data is written by JSONFormatter, in cases where where run is aborted.

Ref. #842 