### PR TITLE
Docs: change code blocks from bash to console

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,7 @@ In that directory create a file called "example_steps.py" containing:
 
 Run behave:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ behave
     Feature: Showing off behave # features/example.feature:2

--- a/docs/practical_tips.rst
+++ b/docs/practical_tips.rst
@@ -30,7 +30,7 @@ For example, if you want to use the feature files in the same directory for
 testing the model layer and the UI layer, this can be done by using the
 ``--stage`` option, like with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ behave --stage=model features/
     $ behave --stage=ui    features/  # NOTE: Normally used on a subset of features.


### PR DESCRIPTION
Changed code block language of interactive shell session examples from `bash` to `console`. 

`bash` is used for shell scripts, rather than interactive sessions, and highlights certain words in the console output on both GitHub and PyPI. Changing the code block language to `console` should work on both PyPI (Pygments) and GitHub.