### PR TITLE
Add Contributing chapter

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,7 +108,7 @@ if USE_SPHINX_INTERNATIONAL:
 # -----------------------------------------------------------------------------
 project = u"behave"
 authors = u"Jens Engel, Benno Rice and Richard Jones"
-copyright = u"2012-2019, %s" % authors
+copyright = u"2012-2020, %s" % authors
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,0 +1,82 @@
+Contributing
+============
+
+If you find a bug you can fix or want to contribute an enhancement you're
+welcome to `open an issue`_ on GitHub or create a `pull request`_ directly.
+
+.. _open an issue: https://github.com/behave/behave/issues
+.. _pull request: https://github.com/behave/behave/pulls
+
+Using ``invoke`` for Development
+--------------------------------
+
+For most development tasks we have `invoke`_ commands.
+
+Install all requirements for running tasks using Pip, e.g.
+
+.. code-block:: console
+
+    python3 -m pip install -r tasks/py.requirements.txt
+
+Display all available ``invoke`` commands like this:
+
+.. code-block:: console
+
+    invoke -l
+
+If you're curious, all ``invoke`` tasks are located in the ``tasks/``
+folder.
+
+.. _invoke: https://www.pyinvoke.org/
+
+Update Gherkin Language Specification
+-------------------------------------
+
+An ``invoke`` command will download the latest Gherkin language
+specification and update the `behave/i18n.py`_ module:
+
+.. code-block:: console
+
+    invoke develop.update-gherkin
+
+If there were changes this command will have updated two files:
+
+#. ``etc/gherkin/gherkin-languages.json`` (original Cucumber JSON spec)
+#. ``behave/i18n.py`` (Python module generated from the JSON spec)
+
+Put both under version control and open a PR to merge them.
+
+.. _behave/i18n.py:
+    https://github.com/behave/behave/blob/master/behave/i18n.py
+
+Update Documentation
+--------------------
+
+Our documentation is written in `reStructuredText`_, and built and hosted
+on `ReadTheDocs`_. Make your changes to the files in the ``docs/`` folder
+and build the documentation with:
+
+.. code-block:: console
+
+    invoke docs
+
+or, alternatively, using Tox:
+
+.. code-block:: console
+
+    tox -e docs
+
+.. hint::
+
+    Building the docs requires Sphinx and DocUtils. If your build fails
+    because those are missing, run:
+
+        python3 -m pip install -r py.requirements/docs.txt
+
+Once the docs are built successfully, ``sphinx`` will tell you where it
+generated the HTML output (typically ``build/docs/html``), which you can
+then inspect locally.
+
+.. _reStructuredText:
+    https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+.. _ReadTheDocs: https://readthedocs.org/

--- a/docs/formatters.rst
+++ b/docs/formatters.rst
@@ -1,8 +1,8 @@
 .. _id.appendix.formatters:
 
-==============================================================================
+========================
 Formatters and Reporters
-==============================================================================
+========================
 
 :pypi:`behave` provides 2 different concepts for reporting results of a test run:
 
@@ -15,7 +15,7 @@ The ``Reporter`` has a more coarse-grained API.
 
 
 Reporters
-------------------------------------------------------------------------------
+---------
 
 The following reporters are currently supported:
 
@@ -28,7 +28,7 @@ summary         Provides a summary of the test run.
 
 
 Formatters
-------------------------------------------------------------------------------
+----------
 
 The following formatters are currently supported:
 
@@ -62,7 +62,7 @@ tags.location  dry-run  Shows tags and the location where they are used.
 
 
 User-Defined Formatters
-------------------------------------------------------------------------------
+-----------------------
 
 Behave allows you to provide your own formatter (class)::
 
@@ -96,16 +96,16 @@ to provide them. The formatter should use the attribute schema:
 
 
 More Formatters
-------------------------------------------------------------------------------
+---------------
 
-The following formatters are currently known:
+The following contributed formatters are currently known:
 
 ============== =========================================================================
 Name           Description
 ============== =========================================================================
-allure         :pypi:`allure-behave`, an Allure formatter for behave:
-               ``allure_behave.formatter:AllureFormatter``
-teamcity       :pypi:`behave-teamcity`, a formatter for Jetbrains TeamCity CI testruns
+allure         :pypi:`allure-behave`, an Allure formatter for behave.
+html           :pypi:`behave-html-formatter`, a simple HTML formatter for behave.
+teamcity       :pypi:`behave-teamcity`, a formatter for JetBrains TeamCity CI testruns
                with behave.
 ============== =========================================================================
 
@@ -114,5 +114,6 @@ teamcity       :pypi:`behave-teamcity`, a formatter for Jetbrains TeamCity CI te
     # -- FILE: behave.ini
     # FORMATTER ALIASES: behave -f allure ...
     [behave.formatters]
-    allure   = allure_behave.formatter:AllureFormatter
+    allure = allure_behave.formatter:AllureFormatter
+    html = behave_html_formatter:HTMLFormatter
     teamcity = behave_teamcity:TeamcityFormatter

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,7 @@ Contents
    comparison
    new_and_noteworthy
    more_info
+   contributing
    appendix
 
 .. seealso::

--- a/tox.ini
+++ b/tox.ini
@@ -77,12 +77,9 @@ setenv =
 
 
 [testenv:docs]
-basepython= python2
 changedir = docs
-commands=
-    sphinx-build -W -b html -D language=en -d {envtmpdir}/doctrees . {envtmpdir}/html/en
-deps=
-    -r{toxinidir}/py.requirements/docs.txt
+commands = sphinx-build -W -b html -D language=en -d {toxinidir}/build/docs/doctrees . {toxinidir}/build/docs/html/en
+deps = -r{toxinidir}/py.requirements/docs.txt
 
 
 [testenv:cleanroom2]
@@ -146,4 +143,3 @@ commands=
 deps=
     jit
     {[testenv]deps}
-


### PR DESCRIPTION
Adds a new chapter aimed at giving guidance on contributing to Behave.

## Tox configuration

Also adapts the `docs` Tox target, so that it generates the docs at the same location than `invoke docs` (not inside `.tox/tmp/`). This gives us a unified user experience and, as a nice side-effect, the `invoke docs.clean` command will clean up "both" locations.

## Issues with Requirements

Having Tox install `behave` when `tox -e docs` is run requires DocUtils to be prior installed due to some setup that makes `setuptools` verify the package README. We should try to remove this dependency and have the proper README generation checked independently, e.g. [using Twine](https://github.com/bittner/pyclean/blob/master/tox.ini#L46-L51) via a Tox target.