### PR TITLE
FIX: Some regressions in test suite for python 3.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ tools/virtualenvs
 .ropeproject
 nosetests.xml
 rerun.txt
+testrun*.json

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,8 @@ CLARIFICATION:
 
 FIXED:
 
+* FIXED: Some tests related to python3.9
+* FIXED: active-tag logic if multiple tags with same category exists.
 * issue #772: ScenarioOutline.Examples without table (submitted by: The-QA-Geek)
 * issue #755: Failures with Python 3.8 (submitted by: hroncok)
 * issue #725: Scenario Outline description lines seem to be ignored (submitted by: nizwiz)

--- a/behave/api/runtime_constraint.py
+++ b/behave/api/runtime_constraint.py
@@ -7,6 +7,8 @@ Simplifies to specify runtime constraints in
 """
 
 from __future__ import absolute_import
+import six
+import sys
 from behave.exception import ConstraintError
 
 
@@ -19,11 +21,10 @@ def require_min_python_version(minimal_version):
     :param minimal_version: Minimum version (as string, tuple)
     :raises: behave.exception.ConstraintError
     """
-    import six
-    import sys
     python_version = sys.version_info
     if isinstance(minimal_version, six.string_types):
-        python_version = "%s.%s" % sys.version_info[:2]
+        python_version = float("%s.%s" % sys.version_info[:2])
+        minimal_version = float(minimal_version)
     elif not isinstance(minimal_version, tuple):
         raise TypeError("string or tuple (was: %s)" % type(minimal_version))
 
@@ -40,6 +41,9 @@ def require_min_behave_version(minimal_version):
     """
     # -- SIMPLISTIC IMPLEMENTATION:
     from behave.version import VERSION as behave_version
-    if behave_version < minimal_version:
+    behave_version2 = behave_version.split(".")
+    minimal_version2 = minimal_version.split(".")
+    if behave_version2 < minimal_version2:
+        # -- USE: Tuple comparison as version comparison.
         raise ConstraintError("behave >= %s expected (was: %s)" % \
                               (minimal_version, behave_version))

--- a/behave/python_feature.py
+++ b/behave/python_feature.py
@@ -1,0 +1,81 @@
+# -*- coding: UTF-8 -*-
+"""
+Provides a knowledge database if some Python features are supported
+in the current python version.
+"""
+
+from __future__ import absolute_import
+import sys
+import six
+from behave.tag_matcher import bool_to_string
+
+
+# -----------------------------------------------------------------------------
+# CONSTANTS:
+# -----------------------------------------------------------------------------
+PYTHON_VERSION = sys.version_info[:2]
+
+
+# -----------------------------------------------------------------------------
+# CLASSES:
+# -----------------------------------------------------------------------------
+class PythonFeature(object):
+
+    @staticmethod
+    def has_asyncio_coroutine_decorator():
+        """Indicates if python supports ``@asyncio.coroutine`` decorator.
+
+        EXAMPLE::
+
+            import asyncio
+            @asyncio.coroutine
+            def async_waits_seconds(duration):
+                yield from asyncio.sleep(duration)
+
+        :returns: True, if this python version supports this feature.
+
+        .. since:: Python >= 3.4
+        .. deprecated:: Since Python 3.8 (use async-function instead)
+        """
+        # -- NOTE: @asyncio.coroutine is deprecated in py3.8, removed in py3.10
+        return (3, 4) <= PYTHON_VERSION < (3, 10)
+
+    @staticmethod
+    def has_async_function():
+        """Indicates if python supports async-functions / async-keyword.
+
+        EXAMPLE::
+
+            import asyncio
+            async def async_waits_seconds(duration):
+                yield from asyncio.sleep(duration)
+
+        :returns: True, if this python version supports this feature.
+        .. since:: Python >= 3.5
+        """
+        return (3, 5) <= PYTHON_VERSION
+
+    @classmethod
+    def has_coroutine(cls):
+        return cls.has_async_function() or cls.has_asyncio_coroutine_decorator()
+
+
+# -----------------------------------------------------------------------------
+# SUPPORTED: ACTIVE-TAGS
+# -----------------------------------------------------------------------------
+PYTHON_HAS_ASYNCIO_COROUTINE_DECORATOR = PythonFeature.has_asyncio_coroutine_decorator()
+PYTHON_HAS_ASYNC_FUNCTION = PythonFeature.has_async_function()
+PYTHON_HAS_COROUTINE = PythonFeature.has_coroutine()
+ACTIVE_TAG_VALUE_PROVIDER = {
+    "python2": bool_to_string(six.PY2),
+    "python3": bool_to_string(six.PY3),
+    "python.version": "%s.%s" % PYTHON_VERSION,
+    "os":      sys.platform.lower(),
+
+    # -- PYTHON FEATURE, like: @use.with_py.feature_asyncio.coroutine
+    "python_has_coroutine": bool_to_string(PYTHON_HAS_COROUTINE),
+    "python_has_asyncio.coroutine_decorator":
+        bool_to_string(PYTHON_HAS_ASYNCIO_COROUTINE_DECORATOR),
+    "python_has_async_function": bool_to_string(PYTHON_HAS_ASYNC_FUNCTION),
+    "python_has_async_keyword": bool_to_string(PYTHON_HAS_ASYNC_FUNCTION),
+}

--- a/bin/behave
+++ b/bin/behave
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 

--- a/bin/behave
+++ b/bin/behave
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import

--- a/bin/invoke
+++ b/bin/invoke
@@ -1,8 +1,0 @@
-#!/bin/sh
-#!/bin/bash
-# RUN INVOKE: From bundled ZIP file.
-
-HERE=$(dirname $0)
-export INVOKE_TASKS_USE_VENDOR_BUNDLES="yes"
-
-python ${HERE}/../tasks/_vendor/invoke.zip $*

--- a/bin/invoke.cmd
+++ b/bin/invoke.cmd
@@ -1,9 +1,0 @@
-@echo off
-REM RUN INVOKE: From bundled ZIP file.
-
-setlocal
-set HERE=%~dp0
-set INVOKE_TASKS_USE_VENDOR_BUNDLES="yes"
-if not defined PYTHON   set PYTHON=python
-
-%PYTHON% %HERE%../tasks/_vendor/invoke.zip "%*"

--- a/bin/json.format.py
+++ b/bin/json.format.py
@@ -10,8 +10,8 @@ LICENSE:  BSD
 from __future__ import absolute_import
 
 __author__    = "Jens Engel"
-__copyright__ = "(c) 2011-2013 by Jens Engel"
-VERSION = "0.2.2"
+__copyright__ = "(c) 2011-2021 by Jens Engel"
+VERSION = "0.3.0"
 
 # -- IMPORTS:
 import os.path
@@ -29,6 +29,7 @@ except ImportError:
 # CONSTANTS:
 # ----------------------------------------------------------------------------
 DEFAULT_INDENT_SIZE = 2
+PYTHON_VERSION = sys.version_info[:2]
 
 # ----------------------------------------------------------------------------
 # FUNCTIONS:
@@ -58,7 +59,11 @@ def json_format(filename, indent=DEFAULT_INDENT_SIZE, **kwargs):
 #        return 0
 
     contents = open(filename, "r").read()
-    data      = json.loads(contents, encoding=encoding)
+    if PYTHON_VERSION >= (3, 1):
+        # -- NOTE: encoding keyword is deprecated since python 3.1
+        data = json.loads(contents)
+    else:
+        data = json.loads(contents, encoding=encoding)
     contents2 = json.dumps(data, indent=indent, sort_keys=sort_keys)
     contents2 = contents2.strip()
     contents2 = "%s\n" % contents2
@@ -69,7 +74,7 @@ def json_format(filename, indent=DEFAULT_INDENT_SIZE, **kwargs):
         outfile = open(filename, "w")
         outfile.write(contents2)
         outfile.close()
-        console.warn("%s OK", message)
+        console.warning("%s OK", message)
         return 1 #< OK
 
 def json_formatall(filenames, indent=DEFAULT_INDENT_SIZE, dry_run=False):
@@ -143,7 +148,7 @@ Format/Beautify one or more JSON file(s)."""
                 console.info("SKIP %s, no JSON files found in dir.", filename)
                 skipped += 1
         elif not os.path.exists(filename):
-            console.warn("SKIP %s, file not found.", filename)
+            console.warning("SKIP %s, file not found.", filename)
             skipped += 1
             continue
         else:

--- a/bin/jsonschema_validate.py
+++ b/bin/jsonschema_validate.py
@@ -18,11 +18,11 @@ from __future__ import absolute_import, print_function
 __author__  = "Jens Engel"
 __version__ = "0.1.0"
 
-from jsonschema import validate
 import argparse
 import os.path
 import sys
 import textwrap
+from jsonschema import validate
 try:
     import json
 except ImportError:
@@ -38,16 +38,28 @@ except ImportError:
 HERE = os.path.dirname(__file__)
 TOP  = os.path.normpath(os.path.join(HERE, ".."))
 SCHEMA = os.path.join(TOP, "etc", "json", "behave.json-schema")
+PYTHON_VERSION = sys.version_info[:2]
 
 
 # -----------------------------------------------------------------------------
 # FUNCTIONS:
 # -----------------------------------------------------------------------------
-def jsonschema_validate(filename, schema, encoding=None):
+def json_loads(text, encoding=None):
+    kwargs = {}
+    if encoding and PYTHON_VERSION < (3, 1):
+        # -- NOTE: encoding keyword is deprecated since python 3.1
+        kwargs["encoding"] = encoding
+    return json.loads(text, **kwargs)
+
+def json_load(filename, encoding=None):
     f = open(filename, "r")
     contents = f.read()
     f.close()
-    data = json.loads(contents, encoding=encoding)
+    data = json_loads(contents, encoding=encoding)
+    return data
+
+def jsonschema_validate(filename, schema, encoding=None):
+    data = json_load(filename, encoding=encoding)
     return validate(data, schema)
 
 
@@ -89,10 +101,7 @@ def main(args=None):
         parser.error("SCHEMA not found: %s" % options.schema)
 
     try:
-        f = open(options.schema, "r")
-        contents = f.read()
-        f.close()
-        schema = json.loads(contents, encoding=options.encoding)
+        schema = json_load(options.schema, encoding=options.encoding)
     except Exception as e:
         msg = "ERROR: %s: %s (while loading schema)" % (e.__class__.__name__, e)
         sys.exit(msg)

--- a/etc/json/behave.json-schema
+++ b/etc/json/behave.json-schema
@@ -28,8 +28,34 @@
             "type": "object",
             "anyOf": [
                 { "$ref": "#/definitions/Background" },
+                { "$ref": "#/definitions/Rule" },
                 { "$ref": "#/definitions/Scenario" },
                 { "$ref": "#/definitions/ScenarioOutline" }
+            ]
+        },
+        "Rule": {
+            "type": "object",
+            "description": "Represents a Rule object.",
+            "properties": {
+                "name":     { "type": "string" },
+                "keyword":  { "type": "string" },
+                "location": { "type": "string" },
+                "status":   { "type": "string" },
+                "tags":     { "$ref": "#/definitions/Tags" },
+                "description": { "$ref": "#/definitions/MultiLineText" },
+                "elements": {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/RuleElement" }
+                }
+            },
+            "required": [ "name", "keyword", "location" ]
+        },
+        "RuleElement": {
+            "type": "object",
+            "anyOf": [
+                { "$ref": "#/definitions/Scenario" },
+                { "$ref": "#/definitions/ScenarioOutline" },
+                { "$ref": "#/definitions/Background" }
             ]
         },
         "Background": {

--- a/examples/async_step/features/async_dispatch.feature
+++ b/examples/async_step/features/async_dispatch.feature
@@ -1,8 +1,5 @@
-@use.with_python.version=3.4
-@use.with_python.version=3.5
-@use.with_python.version=3.6
-@use.with_python.version=3.7
-@use.with_python.version=3.8
+@use.with_python_has_async_function=true
+@use.with_python_has_asyncio.coroutine_decorator=true
 Feature:
   Scenario:
     Given I dispatch an async-call with param "Alice"

--- a/examples/async_step/features/async_run.feature
+++ b/examples/async_step/features/async_run.feature
@@ -1,8 +1,5 @@
-@use.with_python.version=3.4
-@use.with_python.version=3.5
-@use.with_python.version=3.6
-@use.with_python.version=3.7
-@use.with_python.version=3.8
+@use.with_python_has_async_function=true
+@use.with_python_has_asyncio.coroutine_decorator=true
 Feature:
   Scenario:
     Given an async-step waits 0.3 seconds

--- a/examples/async_step/features/environment.py
+++ b/examples/async_step/features/environment.py
@@ -2,7 +2,8 @@
 
 from behave.tag_matcher import ActiveTagMatcher, setup_active_tag_values
 from behave.api.runtime_constraint import require_min_python_version
-import sys
+from behave import python_feature
+
 
 # -----------------------------------------------------------------------------
 # REQUIRE: python >= 3.4
@@ -15,27 +16,24 @@ require_min_python_version("3.4")
 # -----------------------------------------------------------------------------
 # -- MATCHES ANY TAGS: @use.with_{category}={value}
 # NOTE: active_tag_value_provider provides category values for active tags.
-python_version = "%s.%s" % sys.version_info[:2]
-active_tag_value_provider = {
-    "python.version": python_version,
-}
+active_tag_value_provider = python_feature.ACTIVE_TAG_VALUE_PROVIDER.copy()
 active_tag_matcher = ActiveTagMatcher(active_tag_value_provider)
 
 
 # -----------------------------------------------------------------------------
 # HOOKS:
 # -----------------------------------------------------------------------------
-def before_all(context):
+def before_all(ctx):
     # -- SETUP ACTIVE-TAG MATCHER (with userdata):
-    setup_active_tag_values(active_tag_value_provider, context.config.userdata)
+    setup_active_tag_values(active_tag_value_provider, ctx.config.userdata)
 
 
-def before_feature(context, feature):
+def before_feature(ctx, feature):
     if active_tag_matcher.should_exclude_with(feature.tags):
         feature.skip(reason=active_tag_matcher.exclude_reason)
 
 
-def before_scenario(context, scenario):
+def before_scenario(ctx, scenario):
     if active_tag_matcher.should_exclude_with(scenario.effective_tags):
         scenario.skip(reason=active_tag_matcher.exclude_reason)
 

--- a/examples/async_step/features/steps/_async_steps34.py
+++ b/examples/async_step/features/steps/_async_steps34.py
@@ -1,5 +1,5 @@
-# -- REQUIRES: Python >= 3.4 and Python < 3.8
-# HINT: Decorator @asyncio.coroutine is prohibited in python 3.8
+# -- REQUIRES: Python >= 3.4 and Python < 3.10 (removed in: 3.10)
+# HINT: @asyncio.coroutine decorator is deprecated since python 3.8
 # USE:  Async generator/coroutine instead.
 
 from behave import step

--- a/examples/async_step/features/steps/async_dispatch_steps.py
+++ b/examples/async_step/features/steps/async_dispatch_steps.py
@@ -1,8 +1,9 @@
 # -*- coding: UTF-8 -*-
 # REQUIRES: Python >= 3.4/3.5
-import sys
+
 from behave import given, then, step
 from behave.api.async_step import use_or_create_async_context
+from behave.python_feature import PythonFeature
 from hamcrest import assert_that, equal_to, empty
 import asyncio
 
@@ -10,13 +11,15 @@ import asyncio
 # ---------------------------------------------------------------------------
 # ASYNC EXAMPLE FUNCTION:
 # ---------------------------------------------------------------------------
-python_version = "%s.%s" % sys.version_info[:2]
-if python_version >= "3.5":
+if PythonFeature.has_async_function():
+    # -- USE: async-function as coroutine-function
+    # SINCE: Python 3.5 (preferred)
     async def async_func(param):
         await asyncio.sleep(0.2)
         return str(param).upper()
-else:
-    # -- HINT: Decorator @asyncio.coroutine is prohibited in python 3.8
+elif PythonFeature.has_asyncio_coroutine_decorator():
+    # -- USE: @asyncio.coroutine decorator
+    # SINCE: Python 3.4, deprecated since Python 3.8, removed in Python 3.10
     @asyncio.coroutine
     def async_func(param):
         yield from asyncio.sleep(0.2)

--- a/examples/async_step/features/steps/async_steps.py
+++ b/examples/async_step/features/steps/async_steps.py
@@ -5,8 +5,8 @@
 from __future__ import absolute_import
 import sys
 
-python_version = "%s.%s" % sys.version_info[:2]
-if python_version >= "3.5":
+python_version = sys.version_info[:2]
+if python_version >= (3, 5):
     import _async_steps35
-elif python_version == "3.4":
+elif python_version == (3, 4):
     import _async_steps34

--- a/features/environment.py
+++ b/features/environment.py
@@ -4,22 +4,19 @@
 from __future__ import absolute_import, print_function
 from behave.tag_matcher import ActiveTagMatcher, setup_active_tag_values
 from behave4cmd0.setup_command_shell import setup_command_shell_processors4behave
+from behave import python_feature
 import platform
 import sys
-import six
+
 
 # -- MATCHES ANY TAGS: @use.with_{category}={value}
 # NOTE: active_tag_value_provider provides category values for active tags.
-python_version = "%s.%s" % sys.version_info[:2]
 active_tag_value_provider = {
-    "python2": str(six.PY2).lower(),
-    "python3": str(six.PY3).lower(),
-    "python.version": python_version,
     # -- python.implementation: cpython, pypy, jython, ironpython
     "python.implementation": platform.python_implementation().lower(),
     "pypy":    str("__pypy__" in sys.modules).lower(),
-    "os":      sys.platform,
 }
+active_tag_value_provider.update(python_feature.ACTIVE_TAG_VALUE_PROVIDER)
 active_tag_matcher = ActiveTagMatcher(active_tag_value_provider)
 
 
@@ -27,7 +24,7 @@ def print_active_tags_summary():
     active_tag_data = active_tag_value_provider
     print("ACTIVE-TAG SUMMARY:")
     print("use.with_python.version=%s" % active_tag_data.get("python.version"))
-    # print("use.with_os=%s" % active_tag_data.get("os"))
+    print("use.with_os=%s" % active_tag_data.get("os"))
     print()
 
 
@@ -52,6 +49,7 @@ def before_feature(context, feature):
 def before_scenario(context, scenario):
     if active_tag_matcher.should_exclude_with(scenario.effective_tags):
         scenario.skip(reason=active_tag_matcher.exclude_reason)
+
 
 # -----------------------------------------------------------------------------
 # SPECIFIC FUNCTIONALITY:

--- a/features/step.async_steps.feature
+++ b/features/step.async_steps.feature
@@ -32,6 +32,9 @@ Feature: Async-Test Support (async-step, ...)
 
     @use.with_python.version=3.5
     @use.with_python.version=3.6
+    @use.with_python.version=3.7
+    @use.with_python.version=3.8
+    @use.with_python.version=3.9
     Scenario: Use async-step with @async_run_until_complete (async)
       Given a new working directory
       And a file named "features/steps/async_steps35.py" with:
@@ -63,6 +66,9 @@ Feature: Async-Test Support (async-step, ...)
     @use.with_python.version=3.4
     @use.with_python.version=3.5
     @use.with_python.version=3.6
+    @use.with_python.version=3.7
+    @use.with_python.version=3.8
+    @use.with_python.version=3.9
     Scenario: Use async-step with @async_run_until_complete (@coroutine)
       Given a new working directory
       And a file named "features/steps/async_steps34.py" with:
@@ -93,6 +99,9 @@ Feature: Async-Test Support (async-step, ...)
 
     @use.with_python.version=3.5
     @use.with_python.version=3.6
+    @use.with_python.version=3.7
+    @use.with_python.version=3.8
+    @use.with_python.version=3.9
     Scenario: Use @async_run_until_complete(timeout=...) and TIMEOUT occurs (async)
       Given a new working directory
       And a file named "features/steps/async_steps_timeout35.py" with:
@@ -128,6 +137,9 @@ Feature: Async-Test Support (async-step, ...)
 
     @use.with_python.version=3.5
     @use.with_python.version=3.6
+    @use.with_python.version=3.7
+    @use.with_python.version=3.8
+    @use.with_python.version=3.9
     @async_step_fails
     Scenario: Use @async_run_until_complete and async-step fails
       Given a new working directory
@@ -170,6 +182,9 @@ Feature: Async-Test Support (async-step, ...)
 
     @use.with_python.version=3.5
     @use.with_python.version=3.6
+    @use.with_python.version=3.7
+    @use.with_python.version=3.8
+    @use.with_python.version=3.9
     @async_step_fails
     Scenario: Use @async_run_until_complete and async-step raises error
       Given a new working directory
@@ -213,6 +228,9 @@ Feature: Async-Test Support (async-step, ...)
     @use.with_python.version=3.4
     @use.with_python.version=3.5
     @use.with_python.version=3.6
+    @use.with_python.version=3.7
+    @use.with_python.version=3.8
+    @use.with_python.version=3.9
     Scenario: Use @async_run_until_complete(timeout=...) and TIMEOUT occurs (@coroutine)
       Given a new working directory
       And a file named "features/steps/async_steps_timeout34.py" with:
@@ -250,6 +268,9 @@ Feature: Async-Test Support (async-step, ...)
     @use.with_python.version=3.4
     @use.with_python.version=3.5
     @use.with_python.version=3.6
+    @use.with_python.version=3.7
+    @use.with_python.version=3.8
+    @use.with_python.version=3.9
     Scenario: Use async-dispatch and async-collect concepts
       Given a new working directory
       And a file named "features/steps/async_dispatch_steps.py" with:

--- a/features/step.async_steps.feature
+++ b/features/step.async_steps.feature
@@ -1,4 +1,5 @@
 @not.with_python2=true
+@use.with_python_has_coroutine=true
 Feature: Async-Test Support (async-step, ...)
 
   As a test writer and step provider
@@ -16,11 +17,11 @@ Feature: Async-Test Support (async-step, ...)
   .    * an async-function as coroutine using async/await keywords (Python 3.5)
   .    * an async-function tagged with @asyncio.coroutine and using "yield from"
   .
-  .  # -- EXAMPLE CASE 1 (since Python 3.5):
+  .  # -- EXAMPLE CASE 1 (since Python 3.5; preferred):
   .  async def coroutine1(duration):
   .      await asyncio.sleep(duration)
   .
-  .  # -- EXAMPLE CASE 2 (since Python 3.4):
+  .  # -- EXAMPLE CASE 2 (since Python 3.4; deprecated since Python 3.8; removed in Python 3.10):
   .  @asyncio.coroutine
   .  def coroutine2(duration):
   .      yield from asyncio.sleep(duration)
@@ -30,12 +31,8 @@ Feature: Async-Test Support (async-step, ...)
   .   The async-step can directly interact with other async-functions.
 
 
-    @use.with_python.version=3.5
-    @use.with_python.version=3.6
-    @use.with_python.version=3.7
-    @use.with_python.version=3.8
-    @use.with_python.version=3.9
-    Scenario: Use async-step with @async_run_until_complete (async)
+    @use.with_python_has_async_function=true
+    Scenario: Use async-step with @async_run_until_complete (async; requires: py.version >= 3.5)
       Given a new working directory
       And a file named "features/steps/async_steps35.py" with:
         """
@@ -63,13 +60,8 @@ Feature: Async-Test Support (async-step, ...)
         """
 
 
-    @use.with_python.version=3.4
-    @use.with_python.version=3.5
-    @use.with_python.version=3.6
-    @use.with_python.version=3.7
-    @use.with_python.version=3.8
-    @use.with_python.version=3.9
-    Scenario: Use async-step with @async_run_until_complete (@coroutine)
+    @use.with_python_has_asyncio.coroutine_decorator=true
+    Scenario: Use async-step with @async_run_until_complete (@asyncio.coroutine)
       Given a new working directory
       And a file named "features/steps/async_steps34.py" with:
         """
@@ -97,12 +89,8 @@ Feature: Async-Test Support (async-step, ...)
              Given an async-step waits 0.3 seconds ... passed in 0.3
         """
 
-    @use.with_python.version=3.5
-    @use.with_python.version=3.6
-    @use.with_python.version=3.7
-    @use.with_python.version=3.8
-    @use.with_python.version=3.9
-    Scenario: Use @async_run_until_complete(timeout=...) and TIMEOUT occurs (async)
+    @use.with_python_has_async_function=true
+    Scenario: Use @async_run_until_complete(timeout=...) and TIMEOUT occurs (async-function)
       Given a new working directory
       And a file named "features/steps/async_steps_timeout35.py" with:
         """
@@ -135,13 +123,9 @@ Feature: Async-Test Support (async-step, ...)
         Assertion Failed: TIMEOUT-OCCURED: timeout=0.1
         """
 
-    @use.with_python.version=3.5
-    @use.with_python.version=3.6
-    @use.with_python.version=3.7
-    @use.with_python.version=3.8
-    @use.with_python.version=3.9
+    @use.with_python_has_async_function=true
     @async_step_fails
-    Scenario: Use @async_run_until_complete and async-step fails
+    Scenario: Use @async_run_until_complete and async-step fails (async-function)
       Given a new working directory
       And a file named "features/steps/async_steps_fails35.py" with:
         """
@@ -180,13 +164,9 @@ Feature: Async-Test Support (async-step, ...)
         Assertion Failed: XFAIL in async-step
         """
 
-    @use.with_python.version=3.5
-    @use.with_python.version=3.6
-    @use.with_python.version=3.7
-    @use.with_python.version=3.8
-    @use.with_python.version=3.9
+    @use.with_python_has_async_function=true
     @async_step_fails
-    Scenario: Use @async_run_until_complete and async-step raises error
+    Scenario: Use @async_run_until_complete and async-step raises error (async-function)
       Given a new working directory
       And a file named "features/steps/async_steps_exception35.py" with:
         """
@@ -225,13 +205,8 @@ Feature: Async-Test Support (async-step, ...)
         raise RuntimeError("XFAIL in async-step")
         """
 
-    @use.with_python.version=3.4
-    @use.with_python.version=3.5
-    @use.with_python.version=3.6
-    @use.with_python.version=3.7
-    @use.with_python.version=3.8
-    @use.with_python.version=3.9
-    Scenario: Use @async_run_until_complete(timeout=...) and TIMEOUT occurs (@coroutine)
+    @use.with_python_has_asyncio.coroutine_decorator=true
+    Scenario: Use @async_run_until_complete(timeout=...) and TIMEOUT occurs (@asyncio.coroutine)
       Given a new working directory
       And a file named "features/steps/async_steps_timeout34.py" with:
         """
@@ -265,13 +240,8 @@ Feature: Async-Test Support (async-step, ...)
         Assertion Failed: TIMEOUT-OCCURED: timeout=0.2
         """
 
-    @use.with_python.version=3.4
-    @use.with_python.version=3.5
-    @use.with_python.version=3.6
-    @use.with_python.version=3.7
-    @use.with_python.version=3.8
-    @use.with_python.version=3.9
-    Scenario: Use async-dispatch and async-collect concepts
+    @use.with_python_has_asyncio.coroutine_decorator=true
+    Scenario: Use async-dispatch and async-collect concepts (@asyncio.coroutine)
       Given a new working directory
       And a file named "features/steps/async_dispatch_steps.py" with:
         """

--- a/features/tags.active_tags.feature
+++ b/features/tags.active_tags.feature
@@ -240,9 +240,25 @@ Feature: Active Tags
         | tags                                      | enabled? | Comment |
         | @use.with_foo=xxx   @use.with_foo=other   |  yes     | Enabled: tag1 |
         | @use.with_foo=xxx   @not.with_foo=other   |  yes     | Enabled: tag1, tag2|
-        | @use.with_foo=xxx   @not.with_foo=xxx     |  yes     | Enabled: tag1 (BAD-SPEC) |
-        | @use.with_foo=other @not.with_foo=xxx     |  no      | Enabled: none |
-        | @not.with_foo=other @not.with_foo=xxx     |  yes     | Enabled: tag1 |
+        | @use.with_foo=other @not.with_foo=xxx     |  no      | Disabled: none |
+        | @not.with_foo=other @not.with_foo=xxx     |  no      | Disabled: tag1 |
+        | @use.with_foo=xxx   @not.with_foo=xxx     |  no      | Disabled: tag1 (BAD-SPEC, CONFLICTS) |
+
+
+  Scenario: Tag logic with three active tags of same category
+      Given I setup the current values for active tags with:
+        | category | value |
+        | foo      | xxx   |
+      Then the following active tag combinations are enabled:
+        | tags                                                        | enabled? | Comment |
+        | @use.with_foo=xxx  @use.with_foo=other @use.with_foo=other2|  yes     | Enabled: tag1  |
+        | @use.with_foo=xxx  @use.with_foo=other @not.with_foo=other2|  yes     | Enabled: tag1  |
+        | @use.with_foo=xxx  @not.with_foo=other @use.with_foo=other2|  yes     | Enabled: tag1  |
+        | @use.with_foo=xxx  @not.with_foo=other @not.with_foo=other2|  yes     | Enabled: tag1  |
+        | @not.with_foo=xxx  @use.with_foo=other @use.with_foo=other2|  no      | Disabled: tag1 |
+        | @not.with_foo=xxx  @use.with_foo=other @not.with_foo=other2|  no      | Disabled: tag1 |
+        | @not.with_foo=xxx  @not.with_foo=other @use.with_foo=other2|  no      | Disabled: tag1 |
+        | @not.with_foo=xxx  @not.with_foo=other @not.with_foo=other2|  no      | Disabled: tag1 |
 
 
     Scenario: Tag logic with unknown categories (case: ignored)

--- a/issue.features/issue0330.feature
+++ b/issue.features/issue0330.feature
@@ -72,7 +72,8 @@ Feature: Issue #330: Skipped scenarios are included in junit reports when --no-s
 
   @not.with_python.version=3.8
   @not.with_python.version=3.9
-  Scenario: Junit report for skipped feature is created with --show-skipped
+  @not.with_python.version=3.10
+  Scenario: Junit report for skipped feature is created with --show-skipped (py.version < 3.8)
     When I run "behave --junit -t @tag1 --show-skipped @alice_and_bob.featureset"
     Then it should pass with:
       """
@@ -87,7 +88,8 @@ Feature: Issue #330: Skipped scenarios are included in junit reports when --no-s
 
   @use.with_python.version=3.8
   @use.with_python.version=3.9
-  Scenario: Junit report for skipped feature is created with --show-skipped
+  @use.with_python.version=3.10
+  Scenario: Junit report for skipped feature is created with --show-skipped (py.version >= 3.8)
     When I run "behave --junit -t @tag1 --show-skipped @alice_and_bob.featureset"
     Then it should pass with:
       """
@@ -104,7 +106,8 @@ Feature: Issue #330: Skipped scenarios are included in junit reports when --no-s
 
   @not.with_python.version=3.8
   @not.with_python.version=3.9
-  Scenario: Junit report for skipped scenario is neither shown nor counted with --no-skipped
+  @not.with_python.version=3.10
+  Scenario: Junit report for skipped scenario is neither shown nor counted with --no-skipped (py.version < 3.8)
     When I run "behave --junit -t @tag1 --no-skipped"
     Then it should pass with:
       """
@@ -125,7 +128,8 @@ Feature: Issue #330: Skipped scenarios are included in junit reports when --no-s
 
   @use.with_python.version=3.8
   @use.with_python.version=3.9
-  Scenario: Junit report for skipped scenario is neither shown nor counted with --no-skipped
+  @use.with_python.version=3.10
+  Scenario: Junit report for skipped scenario is neither shown nor counted with --no-skipped (py.version >= 3.8)
     When I run "behave --junit -t @tag1 --no-skipped"
     Then it should pass with:
       """
@@ -149,7 +153,8 @@ Feature: Issue #330: Skipped scenarios are included in junit reports when --no-s
 
   @not.with_python.version=3.8
   @not.with_python.version=3.9
-  Scenario: Junit report for skipped scenario is shown and counted with --show-skipped
+  @not.with_python.version=3.10
+  Scenario: Junit report for skipped scenario is shown and counted with --show-skipped (py.version < 3.8)
     When I run "behave --junit -t @tag1 --show-skipped"
     Then it should pass with:
       """
@@ -171,7 +176,8 @@ Feature: Issue #330: Skipped scenarios are included in junit reports when --no-s
 
   @use.with_python.version=3.8
   @use.with_python.version=3.9
-  Scenario: Junit report for skipped scenario is shown and counted with --show-skipped
+  @use.with_python.version=3.10
+  Scenario: Junit report for skipped scenario is shown and counted with --show-skipped (py.version >= 3.8)
     When I run "behave --junit -t @tag1 --show-skipped"
     Then it should pass with:
       """

--- a/issue.features/issue0330.feature
+++ b/issue.features/issue0330.feature
@@ -71,6 +71,7 @@ Feature: Issue #330: Skipped scenarios are included in junit reports when --no-s
 
 
   @not.with_python.version=3.8
+  @not.with_python.version=3.9
   Scenario: Junit report for skipped feature is created with --show-skipped
     When I run "behave --junit -t @tag1 --show-skipped @alice_and_bob.featureset"
     Then it should pass with:
@@ -85,6 +86,7 @@ Feature: Issue #330: Skipped scenarios are included in junit reports when --no-s
       """
 
   @use.with_python.version=3.8
+  @use.with_python.version=3.9
   Scenario: Junit report for skipped feature is created with --show-skipped
     When I run "behave --junit -t @tag1 --show-skipped @alice_and_bob.featureset"
     Then it should pass with:
@@ -101,6 +103,7 @@ Feature: Issue #330: Skipped scenarios are included in junit reports when --no-s
       # <testsuite errors="0" failures="0" name="bob.Bob" skipped="1" tests="1" time="0.0">
 
   @not.with_python.version=3.8
+  @not.with_python.version=3.9
   Scenario: Junit report for skipped scenario is neither shown nor counted with --no-skipped
     When I run "behave --junit -t @tag1 --no-skipped"
     Then it should pass with:
@@ -121,6 +124,7 @@ Feature: Issue #330: Skipped scenarios are included in junit reports when --no-s
     And note that "Charly2 is the skipped scenarion in charly.feature"
 
   @use.with_python.version=3.8
+  @use.with_python.version=3.9
   Scenario: Junit report for skipped scenario is neither shown nor counted with --no-skipped
     When I run "behave --junit -t @tag1 --no-skipped"
     Then it should pass with:
@@ -144,6 +148,7 @@ Feature: Issue #330: Skipped scenarios are included in junit reports when --no-s
 
 
   @not.with_python.version=3.8
+  @not.with_python.version=3.9
   Scenario: Junit report for skipped scenario is shown and counted with --show-skipped
     When I run "behave --junit -t @tag1 --show-skipped"
     Then it should pass with:
@@ -165,6 +170,7 @@ Feature: Issue #330: Skipped scenarios are included in junit reports when --no-s
 
 
   @use.with_python.version=3.8
+  @use.with_python.version=3.9
   Scenario: Junit report for skipped scenario is shown and counted with --show-skipped
     When I run "behave --junit -t @tag1 --show-skipped"
     Then it should pass with:

--- a/issue.features/issue0446.feature
+++ b/issue.features/issue0446.feature
@@ -59,6 +59,7 @@ Feature: Issue #446 -- Support scenario hook-errors with JUnitReporter
         """
 
     @not.with_python.version=3.8
+    @not.with_python.version=3.9
     Scenario: Hook error in before_scenario()
       When I run "behave -f plain --junit features/before_scenario_failure.feature"
       Then it should fail with:
@@ -88,6 +89,7 @@ Feature: Issue #446 -- Support scenario hook-errors with JUnitReporter
 
 
     @use.with_python.version=3.8
+    @use.with_python.version=3.9
     Scenario: Hook error in before_scenario()
       When I run "behave -f plain --junit features/before_scenario_failure.feature"
       Then it should fail with:
@@ -121,6 +123,7 @@ Feature: Issue #446 -- Support scenario hook-errors with JUnitReporter
 
 
     @not.with_python.version=3.8
+    @not.with_python.version=3.9
     Scenario: Hook error in after_scenario()
       When I run "behave -f plain --junit features/after_scenario_failure.feature"
       Then it should fail with:
@@ -152,6 +155,7 @@ Feature: Issue #446 -- Support scenario hook-errors with JUnitReporter
 
 
     @use.with_python.version=3.8
+    @use.with_python.version=3.9
     Scenario: Hook error in after_scenario()
       When I run "behave -f plain --junit features/after_scenario_failure.feature"
       Then it should fail with:

--- a/issue.features/issue0446.feature
+++ b/issue.features/issue0446.feature
@@ -60,7 +60,8 @@ Feature: Issue #446 -- Support scenario hook-errors with JUnitReporter
 
     @not.with_python.version=3.8
     @not.with_python.version=3.9
-    Scenario: Hook error in before_scenario()
+    @not.with_python.version=3.10
+    Scenario: Hook error in before_scenario() (py.version < 3.8)
       When I run "behave -f plain --junit features/before_scenario_failure.feature"
       Then it should fail with:
         """
@@ -90,7 +91,8 @@ Feature: Issue #446 -- Support scenario hook-errors with JUnitReporter
 
     @use.with_python.version=3.8
     @use.with_python.version=3.9
-    Scenario: Hook error in before_scenario()
+    @use.with_python.version=3.10
+    Scenario: Hook error in before_scenario() (py.version >= 3.8)
       When I run "behave -f plain --junit features/before_scenario_failure.feature"
       Then it should fail with:
         """
@@ -124,7 +126,8 @@ Feature: Issue #446 -- Support scenario hook-errors with JUnitReporter
 
     @not.with_python.version=3.8
     @not.with_python.version=3.9
-    Scenario: Hook error in after_scenario()
+    @not.with_python.version=3.10
+    Scenario: Hook error in after_scenario() (py.version < 3.8)
       When I run "behave -f plain --junit features/after_scenario_failure.feature"
       Then it should fail with:
         """
@@ -156,7 +159,8 @@ Feature: Issue #446 -- Support scenario hook-errors with JUnitReporter
 
     @use.with_python.version=3.8
     @use.with_python.version=3.9
-    Scenario: Hook error in after_scenario()
+    @use.with_python.version=3.10
+    Scenario: Hook error in after_scenario() (py.version >= 3.8)
       When I run "behave -f plain --junit features/after_scenario_failure.feature"
       Then it should fail with:
         """

--- a/issue.features/issue0457.feature
+++ b/issue.features/issue0457.feature
@@ -26,7 +26,8 @@ Feature: Issue #457 -- Double-quotes in error messages of JUnit XML reports
 
     @not.with_python.version=3.8
     @not.with_python.version=3.9
-    Scenario: Use failing assertation in a JUnit XML report
+    @not.with_python.version=3.10
+    Scenario: Use failing assertation in a JUnit XML report (py.version < 3.8)
       Given a file named "features/fails1.feature" with:
         """
         Feature:
@@ -48,7 +49,8 @@ Feature: Issue #457 -- Double-quotes in error messages of JUnit XML reports
 
     @use.with_python.version=3.8
     @use.with_python.version=3.9
-    Scenario: Use failing assertation in a JUnit XML report
+    @use.with_python.version=3.10
+    Scenario: Use failing assertation in a JUnit XML report (py.version >= 3.8)
       Given a file named "features/fails1.feature" with:
         """
         Feature:
@@ -73,7 +75,8 @@ Feature: Issue #457 -- Double-quotes in error messages of JUnit XML reports
 
     @not.with_python.version=3.8
     @not.with_python.version=3.9
-    Scenario: Use exception in a JUnit XML report
+    @not.with_python.version=3.10
+    Scenario: Use exception in a JUnit XML report (py.version < 3.8)
       Given a file named "features/fails2.feature" with:
         """
         Feature:
@@ -96,7 +99,8 @@ Feature: Issue #457 -- Double-quotes in error messages of JUnit XML reports
 
     @use.with_python.version=3.8
     @use.with_python.version=3.9
-    Scenario: Use exception in a JUnit XML report
+    @use.with_python.version=3.10
+    Scenario: Use exception in a JUnit XML report (py.version >= 3.8)
       Given a file named "features/fails2.feature" with:
         """
         Feature:

--- a/issue.features/issue0457.feature
+++ b/issue.features/issue0457.feature
@@ -25,6 +25,7 @@ Feature: Issue #457 -- Double-quotes in error messages of JUnit XML reports
 
 
     @not.with_python.version=3.8
+    @not.with_python.version=3.9
     Scenario: Use failing assertation in a JUnit XML report
       Given a file named "features/fails1.feature" with:
         """
@@ -46,6 +47,7 @@ Feature: Issue #457 -- Double-quotes in error messages of JUnit XML reports
         """
 
     @use.with_python.version=3.8
+    @use.with_python.version=3.9
     Scenario: Use failing assertation in a JUnit XML report
       Given a file named "features/fails1.feature" with:
         """
@@ -70,6 +72,7 @@ Feature: Issue #457 -- Double-quotes in error messages of JUnit XML reports
 
 
     @not.with_python.version=3.8
+    @not.with_python.version=3.9
     Scenario: Use exception in a JUnit XML report
       Given a file named "features/fails2.feature" with:
         """
@@ -90,7 +93,9 @@ Feature: Issue #457 -- Double-quotes in error messages of JUnit XML reports
         <error message="My name is &quot;Bob&quot; and &lt;here&gt; I am"
         """
 
+
     @use.with_python.version=3.8
+    @use.with_python.version=3.9
     Scenario: Use exception in a JUnit XML report
       Given a file named "features/fails2.feature" with:
         """

--- a/issue.features/issue0657.feature
+++ b/issue.features/issue0657.feature
@@ -5,6 +5,9 @@ Feature: Issue #657 -- Allow async steps with timeouts to fail when they raise e
 
     @use.with_python.version=3.5
     @use.with_python.version=3.6
+    @use.with_python.version=3.7
+    @use.with_python.version=3.8
+    @use.with_python.version=3.9
     @async_step_fails
     Scenario: Use @async_run_until_complete and async-step fails
       Given a new working directory

--- a/issue.features/issue0657.feature
+++ b/issue.features/issue0657.feature
@@ -1,15 +1,10 @@
-@not.with_python2=true
 @issue
+@not.with_python2=true
 Feature: Issue #657 -- Allow async steps with timeouts to fail when they raise exceptions
 
-
-    @use.with_python.version=3.5
-    @use.with_python.version=3.6
-    @use.with_python.version=3.7
-    @use.with_python.version=3.8
-    @use.with_python.version=3.9
+    @use.with_python_has_async_function=true
     @async_step_fails
-    Scenario: Use @async_run_until_complete and async-step fails
+    Scenario: Use @async_run_until_complete and async-step fails (py.version >= 3.8)
       Given a new working directory
       And a file named "features/steps/async_steps_fails35.py" with:
         """

--- a/more.features/environment.py
+++ b/more.features/environment.py
@@ -1,15 +1,13 @@
 # -*- coding: UTF-8 -*-
 
 from behave.tag_matcher import ActiveTagMatcher, setup_active_tag_values
-import sys
+from behave import python_feature
 
 # -- MATCHES ANY TAGS: @use.with_{category}={value}
 # NOTE: active_tag_value_provider provides category values for active tags.
-python_version = "%s.%s" % sys.version_info[:2]
-active_tag_value_provider = {
-    "python.version": python_version,
-}
+active_tag_value_provider = python_feature.ACTIVE_TAG_VALUE_PROVIDER.copy()
 active_tag_matcher = ActiveTagMatcher(active_tag_value_provider)
+
 
 # -----------------------------------------------------------------------------
 # HOOKS:
@@ -18,9 +16,11 @@ def before_all(context):
     # -- SETUP ACTIVE-TAG MATCHER (with userdata):
     setup_active_tag_values(active_tag_value_provider, context.config.userdata)
 
+
 def before_feature(context, feature):
     if active_tag_matcher.should_exclude_with(feature.tags):
         feature.skip(reason=active_tag_matcher.exclude_reason)
+
 
 def before_scenario(context, scenario):
     if active_tag_matcher.should_exclude_with(scenario.effective_tags):

--- a/more.features/run_examples.feature
+++ b/more.features/run_examples.feature
@@ -29,13 +29,8 @@ Feature: Ensure that all examples are usable
         features/rule_fails.feature:16  F2 -- Fails
       """
 
-
-  @use.with_python.version=3.4
-  @use.with_python.version=3.5
-  @use.with_python.version=3.6
-  @use.with_python.version=3.7
-  @use.with_python.version=3.8
-  Scenario: examples/async_step (needs: py34 or newer)
+  @use.with_python_has_coroutine=true
+  Scenario: examples/async_step (requires: python.version >= 3.4)
     Given I use the directory "examples/async_step" as working directory
     When I run "behave features/"
     Then it should pass

--- a/py.requirements/ci.tox.txt
+++ b/py.requirements/ci.tox.txt
@@ -13,3 +13,5 @@ PyHamcrest <  2.0;   python_version <  '3.0'
 # -- HINT: path.py => path (python-install-package was renamed for python3)
 path.py >= 11.5.0; python_version <  '3.5'
 path >= 13.1.0;    python_version >= '3.5'
+
+jsonschema

--- a/py.requirements/ci.travis.txt
+++ b/py.requirements/ci.travis.txt
@@ -16,6 +16,8 @@ PyHamcrest <  2.0;   python_version <  '3.0'
 path.py >= 11.5.0; python_version <  '3.5'
 path >= 13.1.0;    python_version >= '3.5'
 
+jsonschema
+
 # -- NOTE: Travis.CI tweak related w/ invalid linecache2 tests.
 #    This problem does not exist if you use pip.
 linecache2 >= 1.0; python_version < '3.0'

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 #   Use tox to run tasks (tests, ...) in a clean virtual environment.
 #   Afterwards you can run tox in offline mode, like:
 #
-#       tox -e py27
+#       tox -e py38
 #
 #   Tox can be configured for offline usage.
 #   Initialize local workspace once (download packages, create PyPI index):
@@ -28,7 +28,7 @@
 
 [tox]
 minversion   = 2.3
-envlist      = py27, py37, py38, py36, py35, pypy, docs
+envlist      = py39, py38, py27, py37, py36, py35, pypy3, pypy, docs
 skip_missing_interpreters = True
 sitepackages = False
 indexserver =


### PR DESCRIPTION
Fix some regressions that occur when using Python 3.9:

* async-steps: Use more stable active-tags now.
* JUnit XML related: Adapt to XML attribute ordering changes since Python 3.8 (add missing active-tag for python=3.9).
* Prepare active-tags usage for Python 3.10

OTHERWISE:

* Behave jsonschema: Add some extra elements (related to: gherkin v6 Rule).
