### PR TITLE
fix: malformed table rows warning

### DIFF
--- a/behave/parser.py
+++ b/behave/parser.py
@@ -41,6 +41,7 @@ Keyword aliases:
 # pylint: enable=line-too-long
 
 from __future__ import absolute_import, with_statement
+import logging
 import re
 import sys
 import six
@@ -643,6 +644,10 @@ class Parser(object):
             self.table = None
             self.state = "steps"
             return self.action_steps(line)
+
+        if not re.match(r"^(|.+)\|$", line):
+            logger = logging.getLogger("behave")
+            logger.warning(u"Malformed table row at %s: line %i", self.feature.filename, self.line)
 
         # -- SUPPORT: Escaped-pipe(s) in Gherkin cell values.
         #    Search for pipe(s) that are not preceeded with an escape char.


### PR DESCRIPTION
- Missing the closing `|` in a table row makes its last cell miss a character.
- Displays a warning in the logs if a such malformed table is detected.

The following Scenario:
```
  Scenario: scenario with malformed table in step
    Given dummy step for testing
          | field1 | field2 |
          | abc    | abc
```

parsed the step table as:
```
(Pdb) line
'| abc    | abc'
(Pdb) [cell.replace("\\|", "|").strip() for cell in re.split(r"(?<!\\)\|", line[1:-1])]
['abc', 'ab']
```

I spent some time debugging this before noticing the missing `|`. Now at least it displays a useful log:

```
2021-09-09 12:04:37,185 WARNING Malformed table row at features/integration/jira/functional/scenario_steps.feature: line 35
```
