### PR TITLE
setup.py: Add category to install additional formatters (html, ...)

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -55,3 +55,21 @@ where <tag> is the placeholder for an `existing tag`_.
 
 .. _`Github repository`: https://github.com/behave/behave
 .. _`existing tag`:      https://github.com/behave/behave/tags
+
+
+Optional Dependencies
+---------------------
+
+If needed, additional dependencies can be installed using ``pip install``
+with one of the following installation targets.
+
+==================== ===================================================================
+Installation Target  Description
+==================== ===================================================================
+behave[docs]         Include packages needed for building Behave's documentation.
+behave[develop]      Optional packages helpful for local development.
+behave[formatters]   Install formatters from `behave-contrib`_ to extend the list of
+                     :ref:`id.appendix.formatters<formatters>` provided by default.
+==================== ===================================================================
+
+.. _`behave-contrib`: https://github.com/behave-contrib

--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,9 @@ setup(
             "modernize >= 0.5",
             "pylint",
         ],
+        'formatters': [
+            "behave-html-formatter",
+        ],
     },
     # DISABLED: use_2to3= bool(python_version >= 3.0),
     # DEPRECATED SINCE: setuptools v58.0.2 (2021-09-06)
@@ -142,5 +145,3 @@ setup(
     ],
     zip_safe = True,
 )
-
-


### PR DESCRIPTION
We want to make it easy to include additional formatters that are hosted in the [behave-contrib](https://github.com/behave-contrib) GitHub organization when installing Behave.

Once these changes are merged we may want to improve the integration usability via #890 and #889.

Closes behave-contrib/behave-html-formatter#5