### PR TITLE
migrate to unittest.mock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,8 +94,6 @@ setup(
         "pytest >= 5.0; python_version >= '3.0'",
         "pytest-html >= 1.19.0,<2.0; python_version <  '3.0'",
         "pytest-html >= 2.0;         python_version >= '3.0'",
-        "mock  <  4.0;   python_version <  '3.6'",
-        "mock  >= 4.0;   python_version >= '3.6'",
         "PyHamcrest >= 2.0.2; python_version >= '3.0'",
         "PyHamcrest <  2.0;   python_version <  '3.0'",
 
@@ -117,8 +115,6 @@ setup(
             "pytest >= 5.0; python_version >= '3.0'",
             "pytest-html >= 1.19.0,<2.0; python_version <  '3.0'",
             "pytest-html >= 2.0;         python_version >= '3.0'",
-            "mock  <  4.0;   python_version <  '3.6'",
-            "mock  >= 4.0;   python_version >= '3.6'",
             "PyHamcrest >= 2.0.2; python_version >= '3.0'",
             "PyHamcrest <  2.0;   python_version <  '3.0'",
             "pytest-cov",

--- a/tests/api/_test_async_step34.py
+++ b/tests/api/_test_async_step34.py
@@ -9,7 +9,7 @@ from behave.api.async_step import AsyncContext, use_or_create_async_context
 from behave._stepimport import use_step_import_modules
 from behave.runner import Context, Runner
 import sys
-from mock import Mock
+from unittest.mock import Mock
 import pytest
 
 from .testing_support import StopWatch, SimpleStepContainer

--- a/tests/issues/test_issue0619.py
+++ b/tests/issues/test_issue0619.py
@@ -19,7 +19,7 @@ so the default behaviour of getattr is not executed (see docs).
 
 from __future__ import absolute_import
 from behave.runner import Context, scoped_context_layer
-from mock import Mock
+from unittest.mock import Mock
 
 
 def test_issue__getattr_with_protected_unknown_context_attribute_raises_no_error():

--- a/tests/issues/test_issue0767.py
+++ b/tests/issues/test_issue0767.py
@@ -14,7 +14,7 @@ Behave returns nothing. ::
 This seems to be an oversight.
 """
 
-from mock import Mock
+from unittest.mock import Mock
 from behave.fixture import fixture, use_fixture_by_tag
 from behave.runner import Context
 

--- a/tests/unit/test_capture.py
+++ b/tests/unit/test_capture.py
@@ -6,7 +6,7 @@ Unittests for :mod:`behave.capture` module.
 from __future__ import absolute_import, print_function
 import sys
 from behave.capture import Captured, CaptureController
-from mock import Mock
+from unittest.mock import Mock
 import pytest
 
 # -----------------------------------------------------------------------------

--- a/tests/unit/test_context_cleanups.py
+++ b/tests/unit/test_context_cleanups.py
@@ -13,7 +13,7 @@ OPEN ISSUES:
 from __future__ import print_function
 from behave.runner import Context, scoped_context_layer
 from contextlib import contextmanager
-from mock import Mock, NonCallableMock
+from unittest.mock import Mock, NonCallableMock
 import pytest
 
 

--- a/tests/unit/test_fixture.py
+++ b/tests/unit/test_fixture.py
@@ -12,7 +12,7 @@ from behave.fixture import \
 from behave.runner import Context, CleanupError, scoped_context_layer
 from behave._types import Unknown
 import pytest
-from mock import Mock
+from unittest.mock import Mock
 import six
 
 

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -7,7 +7,7 @@ import tempfile
 import unittest
 import six
 import pytest
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from behave.formatter._registry import make_formatters
 from behave.formatter import pretty
 from behave.formatter.base import StreamOpener

--- a/tests/unit/test_log_capture.py
+++ b/tests/unit/test_log_capture.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, with_statement
 import pytest
-from mock import patch
+from unittest.mock import patch
 from behave.log_capture import LoggingCapture
 from six.moves import range
 

--- a/tests/unit/test_matchers.py
+++ b/tests/unit/test_matchers.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 from __future__ import absolute_import, with_statement
 import pytest
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import parse
 from behave.matchers import Match, Matcher, ParseMatcher, RegexMatcher, \
     SimplifiedRegexMatcher, CucumberRegexMatcher

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -4,7 +4,7 @@
 from __future__ import absolute_import, print_function, with_statement
 import unittest
 import pytest
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import six
 from six.moves import range     # pylint: disable=redefined-builtin
 from six.moves import zip       # pylint: disable=redefined-builtin

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -12,7 +12,7 @@ import unittest
 import six
 from six import StringIO
 import pytest
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from behave import runner_util
 from behave.model import Table
 from behave.step_registry import StepRegistry

--- a/tests/unit/test_step_registry.py
+++ b/tests/unit/test_step_registry.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 # pylint: disable=unused-wildcard-import
 from __future__ import absolute_import, with_statement
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from six.moves import range     # pylint: disable=redefined-builtin
 from behave import step_registry
 

--- a/tests/unit/test_tag_matcher.py
+++ b/tests/unit/test_tag_matcher.py
@@ -8,7 +8,7 @@ Unit tests for active tag-matcher (mod:`behave.tag_matcher`).
 """
 
 from __future__ import absolute_import
-from mock import Mock
+from unittest.mock import Mock
 from unittest import TestCase
 import warnings
 import pytest


### PR DESCRIPTION
need to package behave for fedora as mock is deprecated in fedora now (cf https://fedoraproject.org/wiki/Changes/DeprecatePythonMock)

Fixes #1028