### PR TITLE
Add a file with the MIT license for behave/i18n.py

### DIFF
--- a/LICENSE-i18n
+++ b/LICENSE-i18n
@@ -1,0 +1,26 @@
+The file behave/i18n.py is generated from the file gherkin-languages.json in
+the Gherkin project, under the following license:
+
+----
+
+The MIT License (MIT)
+
+Copyright (c) Cucumber Ltd, Gaspar Nagy, Björn Rasmusson, Peter Sergeant
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include README.rst
 include CHANGES.rst
 include MANIFEST.in
 include LICENSE
+include LICENSE-i18n
 include .coveragerc
 include .editorconfig
 include .pycheckrc


### PR DESCRIPTION
Based on:

https://github.com/cucumber/common/raw/96f5c46a95262d20418472271f556b4ba3859004/gherkin/LICENSE