### PR TITLE
parser object `__init__`  not called after `reset_runtime`

### DIFF
--- a/behave/runner_util.py
+++ b/behave/runner_util.py
@@ -674,6 +674,11 @@ def reset_runtime():
     matchers.ParseMatcher.custom_types = {}
     matchers.current_matcher = matchers.ParseMatcher
 
-    from importlib import reload
+    if sys.version_info.major > 2:  # reload is a builtin in 2.x
+        if sys.version_info.minor >= 4: # imp was deprecated in 3.4
+            from importlib import reload
+        else:
+            from imp import reload  # pylint: disable=deprecated-module
+
     import parse
     reload(parse)

--- a/behave/runner_util.py
+++ b/behave/runner_util.py
@@ -662,20 +662,24 @@ def print_undefined_step_snippets(undefined_steps, stream=None, colored=True):
     stream.write(msg)
     stream.flush()
 
-def reset_runtime():
+def reset_runtime(reset_registry=True, reset_matchers=True, reset_parse=True):
     """Reset runtime environment.
     Best effort to reset module data to initial state.
     """
-    from behave import step_registry
-    from behave import matchers
     # -- RESET 1: behave.step_registry
-    step_registry.registry = step_registry.StepRegistry()
-    step_registry.setup_step_decorators(None, step_registry.registry)
+    if reset_registry:
+        from behave import step_registry
+        step_registry.registry = step_registry.StepRegistry()
+        step_registry.setup_step_decorators(None, step_registry.registry)
+
     # -- RESET 2: behave.matchers
-    matchers.ParseMatcher.custom_types = {}
-    matchers.current_matcher = matchers.ParseMatcher
+    if reset_matchers:
+        from behave import matchers
+        matchers.ParseMatcher.custom_types = {}
+        matchers.current_matcher = matchers.ParseMatcher
 
     # -- RESET 3: reload parse module, so that parse.Parser instances 
     # are initialized correctly
-    import parse
-    reload_module(parse)
+    if reset_parse:
+        import parse
+        reload_module(parse)

--- a/behave/runner_util.py
+++ b/behave/runner_util.py
@@ -10,6 +10,7 @@ import os.path
 import re
 import sys
 from six import string_types
+from six.moves import reload_module
 from behave import parser
 from behave.exception import \
     FileNotFoundError, InvalidFileLocationError, InvalidFilenameError
@@ -674,11 +675,7 @@ def reset_runtime():
     matchers.ParseMatcher.custom_types = {}
     matchers.current_matcher = matchers.ParseMatcher
 
-    if sys.version_info.major > 2:  # reload is a builtin in 2.x
-        if sys.version_info.minor >= 4: # imp was deprecated in 3.4
-            from importlib import reload
-        else:
-            from imp import reload  # pylint: disable=deprecated-module
-
+    # -- RESET 3: reload parse module, so that parse.Parser instances 
+    # are initialized correctly
     import parse
-    reload(parse)
+    reload_module(parse)

--- a/behave/runner_util.py
+++ b/behave/runner_util.py
@@ -673,3 +673,7 @@ def reset_runtime():
     # -- RESET 2: behave.matchers
     matchers.ParseMatcher.custom_types = {}
     matchers.current_matcher = matchers.ParseMatcher
+
+    from importlib import reload
+    import parse
+    reload(parse)


### PR DESCRIPTION
After executing `reset_runtime` and "running" behave again there would be an exception related to attributes on the `behave.matchers.ParseMatcher.parser` object.

The fix for this was to reload the `parse` module in `reset_runtime`.

Also added arguments to `reset_runtime` to selectively being able to reset specific parts of the runtime.