### PR TITLE
ADD allowing extra CLI args to be passed to Runners

### DIFF
--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -605,7 +605,8 @@ class Configuration(object):
             load_configuration(self.defaults, verbose=verbose)
         parser = setup_parser()
         parser.set_defaults(**self.defaults)
-        args = parser.parse_args(command_args)
+        args, unknown_args = parser.parse_known_args(command_args)
+        self.unknown_args = unknown_args
         for key, value in six.iteritems(args.__dict__):
             if key.startswith("_") and key not in self.cmdline_only_options:
                 continue

--- a/behave/runner.py
+++ b/behave/runner.py
@@ -5,6 +5,7 @@ This module provides Runner class to run behave feature files (or model elements
 
 from __future__ import absolute_import, print_function, with_statement
 
+import argparse
 import contextlib
 import os.path
 import sys
@@ -568,6 +569,11 @@ class ModelRunner(object):
     # pylint: disable=too-many-instance-attributes
 
     def __init__(self, config, features=None, step_registry=None):
+
+        self.runner_args = dict()
+        if config and config.unknown_args:
+            self.runner_args = self.get_parser().parse_args(config.unknown_args)
+
         self.config = config
         self.features = features or []
         self.hooks = {}
@@ -592,6 +598,18 @@ class ModelRunner(object):
         # pylint: disable=protected-access
         assert self.context, "REQUIRE: context, but context=%r" % self.context
         self.context._set_root_attribute("aborted", bool(value))
+
+    def get_parser(self):
+        """Return a parser to parse extra command line arguments.
+
+        "Unknown" command line arguments are tolerated by behave's main argument parser, and passed
+        to the runner implementation. The default implementation of the extra argument parser is
+        the empty parser, i.e. it will reject any unknown argument and fail.
+
+        Custom runner implementors may override this function to return an argparse parser, which
+        accepts specific arguments.
+        """
+        return argparse.ArgumentParser()
 
     aborted = property(_get_aborted, _set_aborted,
                        doc="Indicates that test run is aborted by the user.")


### PR DESCRIPTION
Changing the main argument parser to accept "unknown" args. Let the Runner superclass parse "unknown" args into "extra args". The default Runner implementation doesn't accept any extra args, to restore the original semantics. However, having that, custom Runner classes can now provide own argparsers to accept extra-args from the CLI.