### PR TITLE
Update runner_util.py fix ValueError: list.remove(x): x not in list

### DIFF
--- a/behave/runner_util.py
+++ b/behave/runner_util.py
@@ -446,7 +446,8 @@ class PathManager(object):
 
     def __exit__(self, *crap):
         for path in self.paths:
-            sys.path.remove(path)
+            if path in sys.path:
+                sys.path.remove(path)
         self.paths = None
 
     def add(self, path):


### PR DESCRIPTION
I tried to run behave from intellij today for first time and got this error: `ValueError: list.remove(x): x not in list` when I added this it fixed it to me and since then I can run behave, before that consistently failed on this, no other change was reuired now .feature run file.  my version 1.2.6.

Stack trace before update:

```
Traceback (most recent call last):
  File "/opt/homebrew/Caskroom/miniconda/base/envs/myenv/bin/behave", line 8, in <module>
    sys.exit(main())
  File "/opt/homebrew/Caskroom/miniconda/base/envs/myenv/lib/python3.8/site-packages/behave/__main__.py", line 183, in main
    return run_behave(config)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/myenv/lib/python3.8/site-packages/behave/__main__.py", line 127, in run_behave
    failed = runner.run()
  File "/opt/homebrew/Caskroom/miniconda/base/envs/myenv/lib/python3.8/site-packages/behave/runner.py", line 804, in run
    return self.run_with_paths()
  File "/opt/homebrew/Caskroom/miniconda/base/envs/myenv/lib/python3.8/site-packages/behave/runner_util.py", line 280, in __exit__
    sys.path.remove(path)
ValueError: list.remove(x): x not in list
```