### PR TITLE
Formatters: add steps.undefined, unused and undefinedunused

### DIFF
--- a/behave/formatter/_builtins.py
+++ b/behave/formatter/_builtins.py
@@ -28,6 +28,9 @@ _BUILTIN_FORMATS = [
     ("steps.doc",     "behave.formatter.steps:StepsDocFormatter"),
     ("steps.catalog", "behave.formatter.steps:StepsCatalogFormatter"),
     ("steps.usage",   "behave.formatter.steps:StepsUsageFormatter"),
+    ("steps.undefined",   "behave.formatter.steps:StepsUndefinedFormatter"),
+    ("steps.unused",  "behave.formatter.steps:StepsUnusedFormatter"),
+    ("steps.unusedundefined", "behave.formatter.steps:StepsUnusedUndefinedFormatter"),
     ("sphinx.steps",  "behave.formatter.sphinx_steps:SphinxStepsFormatter"),
 ]
 

--- a/behave/formatter/steps.py
+++ b/behave/formatter/steps.py
@@ -488,6 +488,76 @@ class StepsUsageFormatter(AbstractStepsFormatter):
             self.stream.write(schema % (step_text, step.location))
 
 # -----------------------------------------------------------------------------
+# CLASS: StepsUndefinedFormatter
+# -----------------------------------------------------------------------------
+class StepsUndefinedFormatter(StepsUsageFormatter):
+    """
+    Provides formatter class that shows lists undefined steps.
+
+    EXAMPLE:
+        $ behave --dry-run -f steps.undefined features/
+        ...
+
+    .. note::
+        Supports behave dry-run mode.
+    """
+    name = "steps.undefined"
+    description = "Shows undefined steps."
+    doc_prefix = make_indentation(4)
+    min_location_column = 40
+
+    def report(self):
+        self.report_undefined_steps()
+        self.stream.write("\n")
+
+# -----------------------------------------------------------------------------
+# CLASS: StepsUnusedFormatter
+# -----------------------------------------------------------------------------
+class StepsUnusedFormatter(StepsUsageFormatter):
+    """
+    Provides formatter class that shows lists unused steps.
+
+    EXAMPLE:
+        $ behave --dry-run -f steps.unused features/
+        ...
+
+    .. note::
+        Supports behave dry-run mode.
+    """
+    name = "steps.unused"
+    description = "Shows unused steps."
+    doc_prefix = make_indentation(4)
+    min_location_column = 40
+
+    def report(self):
+        self.report_unused_step_definitions()
+        self.stream.write("\n")
+
+# -----------------------------------------------------------------------------
+# CLASS: StepsUnusedUndefinedFormatter
+# -----------------------------------------------------------------------------
+class StepsUnusedUndefinedFormatter(StepsUsageFormatter):
+    """
+    Provides formatter class that shows lists unused steps.
+
+    EXAMPLE:
+        $ behave --dry-run -f steps.unusedundefined features/
+        ...
+
+    .. note::
+        Supports behave dry-run mode.
+    """
+    name = "steps.unusedundefined"
+    description = "Shows unused steps."
+    doc_prefix = make_indentation(4)
+    min_location_column = 40
+
+    def report(self):
+        self.report_unused_step_definitions()
+        self.report_undefined_steps()
+        self.stream.write("\n")
+
+# -----------------------------------------------------------------------------
 # UTILITY FUNCTIONS:
 # -----------------------------------------------------------------------------
 def steps_contain(steps, step):


### PR DESCRIPTION
For testing of behave repository itself, it'd be useful to have formatters that would report just faulty steps.

The StepsUsageFormatter implementing 'steps.usage' formatter already does this. This commits just adds derived classes implementing:
  * steps.undefined formatter listing just the undefined steps
  * steps.unused formatter listing just the unused steps
  * steps.unusedundefined listing both

Note:
Due to the way how behave parses steps, in case of typo in a step or param with a wrong tyep, the faulty step will appear in both listings. This is motivation for the third formatter which adds both and may be most useful for projects without many unused steps. :)