### PR TITLE
IMPLEMENT #1164: Support And-Step as initial Scenario step if Background Steps exist

### DIFF
--- a/behave/parser.py
+++ b/behave/parser.py
@@ -743,10 +743,15 @@ class Parser(object):
                     step_type = self.last_step_type
                 elif step_type in ("and", "but"):
                     if not self.last_step_type:
+                        found_step_type = False
                         if self.scenario_container and self.scenario_container.background:
-                            last_background_step = self.scenario_container.background.steps[-1]
-                            self.last_step_type = last_background_step.step_type
-                        else:
+                            if self.scenario_container.background.steps:
+                                # -- HINT: Rule may have default background w/o steps.
+                                last_background_step = self.scenario_container.background.steps[-1]
+                                self.last_step_type = last_background_step.step_type
+                                found_step_type = True
+
+                        if not found_step_type:
                             raise ParserError(u"No previous step",
                                               self.line, self.filename)
                     step_type = self.last_step_type

--- a/behave/parser.py
+++ b/behave/parser.py
@@ -743,8 +743,12 @@ class Parser(object):
                     step_type = self.last_step_type
                 elif step_type in ("and", "but"):
                     if not self.last_step_type:
-                        raise ParserError(u"No previous step",
-                                          self.line, self.filename)
+                        if self.scenario_container and self.scenario_container.background:
+                            last_background_step = self.scenario_container.background.steps[-1]
+                            self.last_step_type = last_background_step.step_type
+                        else:
+                            raise ParserError(u"No previous step",
+                                              self.line, self.filename)
                     step_type = self.last_step_type
                 else:
                     self.last_step_type = step_type

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -408,6 +408,35 @@ Feature: Stuff
             ('then', 'But', 'not the bad stuff', None, None),
         ])
 
+    def test_parses_feature_with_a_scenario_with_background_and_and(self):
+        doc = u"""
+Feature: Stuff
+  Background:
+    Given some background
+    And more background
+
+  Scenario: Doing stuff
+    And with the background
+    When I do stuff
+    Then stuff happens
+""".lstrip()
+        feature = parser.parse_feature(doc)
+        assert feature
+        assert feature.name == "Stuff"
+        assert len(feature.scenarios) == 1
+        assert feature.background
+        assert_compare_steps(feature.background.steps, [
+            ('given', 'Given', 'some background', None, None),
+            ('given', 'And', 'more background', None, None)
+        ])
+
+        assert feature.scenarios[0].name == "Doing stuff"
+        assert_compare_steps(feature.scenarios[0].steps, [
+            ('given', 'And', 'with the background', None, None),
+            ('when', 'When', 'I do stuff', None, None),
+            ('then', 'Then', 'stuff happens', None, None),
+        ])
+
     def test_parses_feature_with_a_step_with_a_string_argument(self):
         doc = u'''
 Feature: Stuff


### PR DESCRIPTION
Some gherkin tests in the wild have no prior step to an `And`, but do have a `Background` (for example, [openCypher's tck Match5.feature](https://github.com/opencypher/openCypher/blob/3983da2fc5dc0de99a7b2095cb69b67f2d51cd2c/tck/features/clauses/match/Match5.feature#L466)). This change gives `behave` the ability to correctly parse such files.