### PR TITLE
Add instructions for extras when installing from GitHub

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -35,33 +35,36 @@ enter the newly created directory "behave-<version>" and run::
     pip install .
 
 
-Using the Github Repository
+Using the GitHub Repository
 ---------------------------
 
 :Category: Bleeding edge
 :Precondition: :pypi:`pip` is installed
 
 Run the following command
-to install the newest version from the `Github repository`_::
-
+to install the newest version from the `GitHub repository`_::
 
     pip install git+https://github.com/behave/behave
 
-To install a tagged version from the `Github repository`_, use::
+To install a tagged version from the `GitHub repository`_, use::
 
     pip install git+https://github.com/behave/behave@<tag>
 
 where <tag> is the placeholder for an `existing tag`_.
 
-.. _`Github repository`: https://github.com/behave/behave
+When installing extras, use ``<tag>#egg=behave[...]``, e.g.::
+
+    pip install git+https://github.com/behave/behave@v1.2.7.dev3#egg=behave[toml]
+
+.. _`GitHub repository`: https://github.com/behave/behave
 .. _`existing tag`:      https://github.com/behave/behave/tags
 
 
 Optional Dependencies
 ---------------------
 
-If needed, additional dependencies can be installed using ``pip install``
-with one of the following installation targets.
+If needed, additional dependencies ("extras") can be installed using
+``pip install`` with one of the following installation targets.
 
 ======================= ===================================================================
 Installation Target     Description


### PR DESCRIPTION
How to install extras when installing from source (GitHub) is not documented yet.

Interestingly, the suggested syntax works (to make Pip not complain) and extras are installed for, e.g., `[docs]` or `[develop]`, but not for `[toml]` . Is there something wrong with [the extras declaration](https://github.com/behave/behave/blob/main/setup.py#L140-L143) maybe? Is it too complex and not resolved as expected? We may need to open a separate issue for that.

Cc @pwoolvett