### PR TITLE
Added matching keywords form gherkin-languages.json for PL

### DIFF
--- a/.attic/i18n.yml
+++ b/.attic/i18n.yml
@@ -454,16 +454,17 @@
 "pl":
   name: Polish
   native: polski
-  feature: Właściwość
+  feature: "Właściwość|Funkcja|Aspekt|Potrzeba biznesowa"
   background: Założenia
-  scenario: Scenariusz
+  scenario: "Scenariusz|Przykład"
   scenario_outline: Szablon scenariusza
   examples: Przykłady
   given: "*|Zakładając|Mając"
-  when: "*|Jeżeli|Jeśli"
+  when: "*|Jeżeli|Jeśli|Gdy|Kiedy"
   then: "*|Wtedy"
   and: "*|Oraz|I"
   but: "*|Ale"
+  rule: "zasada|reguła"
 "pt":
   name: Portuguese
   native: português


### PR DESCRIPTION
When working with `#language: pl` there were missing keywords that are picked up by Gherkin plugin in PyCharm, but weren't picked up by behave stating as those keywords were unrecognized.

in version 1.2.6 behave/i18n.py when installed by pip those keywords are missing, despite being committed in 2019.

Updated:
.attic/i18n.py
basing on
etc/gherkin/gherkin-languages.json 