### PR TITLE
FIX #1189: Do not strip trailing whitespace from multiline text

### DIFF
--- a/behave/parser.py
+++ b/behave/parser.py
@@ -237,7 +237,7 @@ class Parser(object):
         self.reset()
         self.filename = filename
 
-        for line in text.split("\n"):
+        for line in text.splitlines():
             self.line += 1
             if not line.strip() and self.state != "multiline_text":
                 # -- SKIP EMPTY LINES, except in multiline string args.
@@ -666,9 +666,7 @@ class Parser(object):
             self.state = "steps"    # NEXT-STATE: Accept additional step(s).
             return True
 
-        # -- SPECIAL CASE: Strip trailing whitespace (whitespace normalization).
-        # HINT: Required for Windows line-endings, like "\r\n", etc.
-        text_line = line[self.multiline_leading:].rstrip()
+        text_line = line[self.multiline_leading:]
         self.lines.append(text_line)
 
         # -- BETTER DIAGNOSTICS: May remove non-whitespace in execute_steps()
@@ -748,7 +746,7 @@ class Parser(object):
         self.statement = self.rule
         self.state = "rule"
 
-        for line in text.split("\n"):
+        for line in text.splitlines():
             self.line += 1
             if not line.strip() and self.state != "multiline_text":
                 # -- SKIP EMPTY LINES, except in multiline string args.
@@ -866,7 +864,7 @@ class Parser(object):
         self.statement = model.Scenario(filename, 0, u"scenario", u"")
         self.state = "steps"
 
-        for line in text.split("\n"):
+        for line in text.splitlines():
             self.line += 1
             if not line.strip() and self.state != "multiline_text":
                 # -- SKIP EMPTY LINES, except in multiline string args.

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -984,6 +984,38 @@ Feature: Stuff
         with pytest.raises(ParserError):
             parse_feature(text)
 
+    def test_parses_multiline_text_and_preserves_trailing_whitespace(self):
+        # -- ISSUE 1189: Parser removes trailing whitespace in multiline text string.
+        doc = u'''
+Feature: Multiline
+
+  Scenario: Multiline Text with Trailing Whitespace
+    Given a multiline argument with:
+      """
+      Trailing    
+      whitespace at   
+      the end of each   
+      line      
+      """
+    Then the trailing whitespace in each line ist not stripped
+'''.lstrip()
+        feature = parse_feature(doc)
+        assert feature is not None
+        assert feature.name == "Multiline"
+        assert len(feature.scenarios) == 1
+        assert feature.scenarios[0].name == "Multiline Text with Trailing Whitespace"
+        text = "\n".join([
+            "Trailing    ",
+            "whitespace at   ",
+            "the end of each   ",
+            "line      ",
+        ])
+        # pylint: disable=bad-whitespace
+        assert_compare_steps(feature.scenarios[0].steps, [
+            ('given', 'Given', 'a multiline argument with:', text, None),
+            ('then', 'Then', 'the trailing whitespace in each line ist not stripped', None, None),
+        ])
+
 
 class TestParser4AndButSteps(object):
     def test_parse_scenario_with_and_and_but(self):


### PR DESCRIPTION
Fix #1189 

Commit 2b6845e54131 ("FIX: Test regression on Windows") introduced whitespace normalization when parsing feature files. The motivation was to support files with Windows line endings (CRLF). The normalization is achieved by splitting lines on Unix line endings (LF) and removing trailing any whitespace in multi-line text statements.

It turns out that this normalization is a bit too aggressive: it remove any trailing whitespace -- not only the extra CR character -- from lines within the multiline text statement.

Address the issue by changing the line handling: instead of splitting on Unix LF and cleanup leftovers inside parser actions, split the lines correctly using the built-in str.splitlines() which supports a superset of universal newlines. This has the advantage that we get consistent behavior for all kinds of line separators -- including Windows, Unix, classic Mac.