### PR TITLE
Ignore missing tool section when parsing pyproject.toml

### DIFF
--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -585,8 +585,13 @@ def read_toml_config(path):
         # -- HINT: Use simple dictionary for "config".
         config = json.loads(json.dumps(tomllib.load(toml_file)))
 
-    config_tool = config["tool"]
     this_config = {}
+    try:
+        config_tool = config["tool"]
+    except KeyError:
+        # -- SPECIAL CASE: A pyproject.toml may not contain a tool section.
+        #  Skip the parsing in that case.
+        return this_config
 
     for dest, action, value_type in configfile_options_iter(config_tool):
         param_name = dest


### PR DESCRIPTION
This pull request fixes the issue that `behave` crashes, when a `pyproject.toml` is present in the project, which does not contain a `tool` section.
In such a case, `behave` will no just skip the further parsing of the file and return an empty configuration.

Fixes #1202 