### PR TITLE
Introducing behave Guru on Gurubase.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,10 +26,14 @@ behave
    :target: https://app.gitter.im/#/room/#behave_behave:gitter.im
    :alt: Chat at https://gitter.im/behave/behave
 
+.. |badge.gurubase| image:: https://img.shields.io/badge/Gurubase-Ask%20behave%20Guru-006BFF
+   :target: https://gurubase.io/g/behave
+   :alt: Ask behave Guru at https://gurubase.io/g/behave
+
 
 .. |logo| image:: https://raw.github.com/behave/behave/master/docs/_static/behave_logo1.png
 
-|badge.latest_version| |badge.license| |badge.CI_status| |badge.docs_status| |badge.discussions| |badge.gitter|
+|badge.latest_version| |badge.license| |badge.CI_status| |badge.docs_status| |badge.discussions| |badge.gitter| |badge.gurubase|
 
 behave is behavior-driven development, Python style.
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [behave Guru](https://gurubase.io/g/behave) to Gurubase. behave Guru uses the data from this repo and data from the [docs](https://behave.readthedocs.io/en/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "behave Guru" badge, which highlights that behave now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable behave Guru in Gurubase, just let me know that's totally fine.
