### PR TITLE
Multiple, nested steps directories under steps

### DIFF
--- a/behave/runner.py
+++ b/behave/runner.py
@@ -919,12 +919,22 @@ class Runner(ModelRunner):
             self.hooks["before_all"] = self.before_all_default_hook
 
     def load_step_definitions(self, extra_step_paths=None):
+        """
+        Allow steps to import other stuff from the steps dir
+        NOTE: Default matcher can be overridden in "environment.py" hook.
+        Collect directories containing step files
+        """
         if extra_step_paths is None:
             extra_step_paths = []
-        # -- Allow steps to import other stuff from the steps dir
-        # NOTE: Default matcher can be overridden in "environment.py" hook.
+
         steps_dir = os.path.join(self.base_dir, self.config.steps_dir)
-        step_paths = [steps_dir] + list(extra_step_paths)
+        step_paths = set()
+
+        for root, _, files in os.walk(steps_dir):
+            step_paths.add(root)
+
+        step_paths = list(step_paths) + list(extra_step_paths)
+
         load_step_modules(step_paths)
 
     def feature_locations(self):

--- a/features/step.nested_folders.feature
+++ b/features/step.nested_folders.feature
@@ -1,0 +1,14 @@
+Feature: Identically named folders and modules in nested directories are all discovered
+
+Scenario: Steps are found even in identically-named folders, with differing or identical module names
+    When a step is implemented in the root folder
+    And a step is implemented in a sub folder
+    And a step is implemented in a sub-sub folder
+    And a step is implemented in another sub folder
+    And a step is implemented in another sub-sub folder with an identical name
+    And a step module with an identical name exists in the root folder
+    And a step module with an identical name exists in a sub folder
+    And a step module with an identical name exists in a sub-sub folder
+    And a step is implemented in a sub-sub-sub folder with no module in the intermediate level
+    And a step module with an identical name exists in the sub-folder two levels deeper
+    Then the implementation from all nested step modules has been executed

--- a/features/steps/nested_folders_for_steps.py
+++ b/features/steps/nested_folders_for_steps.py
@@ -1,0 +1,25 @@
+from behave import then, when
+
+
+@when('a step is implemented in the root folder')
+def step_impl(context):
+    context.nested_root_visited = True
+
+
+@when('a step module with an identical name exists in the root folder')
+def step_impl(context):
+    context.nested_step_module_in_root_visited = True
+
+
+@then('the implementation from all nested step modules has been executed')
+def step_impl(context):
+    assert context.nested_root_visited
+    assert context.nested_sub_folder1_visited
+    assert context.nested_sub_folder1_sub_folder_visited
+    assert context.nested_sub_folder2_visited
+    assert context.nested_sub_folder2_sub_folder_visited
+    assert context.nested_step_module_in_root_visited
+    assert context.nested_step_module_in_sub_folder1_visited
+    assert context.nested_step_module_in_sub_folder1_sub_folder_visited
+    assert context.nested_sub_folder3_visited
+    assert context.nested_sub_sub_folder3_visited

--- a/features/steps/sub_folder1/nested_folders_for_steps.py
+++ b/features/steps/sub_folder1/nested_folders_for_steps.py
@@ -1,0 +1,5 @@
+from behave import when
+
+@when('a step module with an identical name exists in a sub folder')
+def step_impl(context):
+    context.nested_step_module_in_sub_folder1_visited = True

--- a/features/steps/sub_folder1/sub_folder/nested_folders_for_steps.py
+++ b/features/steps/sub_folder1/sub_folder/nested_folders_for_steps.py
@@ -1,0 +1,5 @@
+from behave import when
+
+@when('a step module with an identical name exists in a sub-sub folder')
+def step_impl(context):
+    context.nested_step_module_in_sub_folder1_sub_folder_visited = True

--- a/features/steps/sub_folder1/sub_folder/sub_folder1_steps.py
+++ b/features/steps/sub_folder1/sub_folder/sub_folder1_steps.py
@@ -1,0 +1,5 @@
+from behave import when
+
+@when('a step is implemented in a sub-sub folder')
+def step_impl(context):
+    context.nested_sub_folder1_sub_folder_visited = True

--- a/features/steps/sub_folder1/sub_folder1_steps.py
+++ b/features/steps/sub_folder1/sub_folder1_steps.py
@@ -1,0 +1,5 @@
+from behave import when
+
+@when('a step is implemented in a sub folder')
+def step_impl(context):
+    context.nested_sub_folder1_visited = True

--- a/features/steps/sub_folder2/sub_folder/sub_folder2_steps.py
+++ b/features/steps/sub_folder2/sub_folder/sub_folder2_steps.py
@@ -1,0 +1,5 @@
+from behave import when
+
+@when('a step is implemented in another sub-sub folder with an identical name')
+def step_impl(context):
+    context.nested_sub_folder2_sub_folder_visited = True

--- a/features/steps/sub_folder2/sub_folder2_steps.py
+++ b/features/steps/sub_folder2/sub_folder2_steps.py
@@ -1,0 +1,5 @@
+from behave import when
+
+@when('a step is implemented in another sub folder')
+def step_impl(context):
+    context.nested_sub_folder2_visited = True

--- a/features/steps/sub_folder3/sub_folder/sub_sub_folder/sub_folder3_steps.py
+++ b/features/steps/sub_folder3/sub_folder/sub_sub_folder/sub_folder3_steps.py
@@ -1,0 +1,5 @@
+from behave import when
+
+@when('a step is implemented in a sub-sub-sub folder with no module in the intermediate level')
+def step_impl(context):
+    context.nested_sub_sub_folder3_visited = True

--- a/features/steps/sub_folder3/sub_folder3_steps.py
+++ b/features/steps/sub_folder3/sub_folder3_steps.py
@@ -1,0 +1,5 @@
+from behave import when
+
+@when('a step module with an identical name exists in the sub-folder two levels deeper')
+def step_impl(context):
+    context.nested_sub_folder3_visited = True


### PR DESCRIPTION
Replaces PR #1151, which has stopped running checks for some unknown reason.

## Original Description

Updated `load_step_definitions` method to recursively search and load step definition files from nested directories within features/steps. This ensures all step files, even those deeply nested, are correctly recognized and loaded by Behave.
Previously, Behave was skipping feature files in nested structures like this:
```
features/
    ├── some_feature.feature
    └── steps/
        └── sub_folder_1/
            └── subfolder/
                └── nested_steps.py (Not executed properly)
```
Enhanced step discovery now encompasses all nested directories, ensuring availability of step definitions at any nesting level for feature tests. Corresponding tests have been added to validate this enhancement.