### PR TITLE
FIX(test_configuration): Explicitly provide args to avoid inheritting from `pytest`

### DIFF
--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -300,7 +300,7 @@ tag_expression_protocol = {value}
         TagExpressionProtocol.use(TagExpressionProtocol.DEFAULT)
         cls.make_config_file_with_tag_expression_protocol(value, tmp_path)
         with use_current_directory(tmp_path):
-            config = Configuration()
+            config = Configuration([])
             print("USE: tag_expression_protocol.value={0}".format(value))
             print("USE: config.tag_expression_protocol={0}".format(
                 config.tag_expression_protocol))
@@ -335,7 +335,7 @@ tag_expression_protocol = {value}
         self.make_config_file_with_tag_expression_protocol(value, tmp_path)
         with use_current_directory(tmp_path):
             with pytest.raises(ValueError) as exc_info:
-                config = Configuration()
+                config = Configuration([])
                 print("USE: tag_expression_protocol.value={0}".format(value))
                 print("USE: config.tag_expression_protocol={0}".format(
                     config.tag_expression_protocol))


### PR DESCRIPTION
If we are not explicit, `Configuration()` tries to parse arguments given to `pytest`, which leads to failure in unit tests that depend on it.

For example, trying to disable timing tests by `python3 -m pytest -k "not test_step_decorator_async_run_until_complete"` results in:

```sh
tests/unit/test_configuration.py:323:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/unit/test_configuration.py:303: in check_tag_expression_protocol_with_valid_value
    config = Configuration()
behave/configuration.py:794: in __init__
    args = parser.parse_args(command_args)
/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/argparse.py:1828: in parse_args
    self.error(msg % ' '.join(argv))
/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/argparse.py:2582: in error
    self.exit(2, _('%(prog)s: error: %(message)s\n') % args)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = ArgumentParser(prog='__main__.py', usage='%(prog)s [options] [DIRECTORY|FILE|FILE:LINE|AT_FILE]*', description='Run a ...atures.txt\n', formatter_class=<class 'argparse.RawDescriptionHelpFormatter'>, conflict_handler='error', add_help=True)
status = 2, message = '__main__.py: error: unrecognized arguments: -k\n'

    def exit(self, status=0, message=None):
        if message:
            self._print_message(message, _sys.stderr)
>       _sys.exit(status)
E       SystemExit: 2
```