### PR TITLE
Update link to Harry Percival's book on TDD

### DIFF
--- a/docs/more_info.rst
+++ b/docs/more_info.rst
@@ -54,12 +54,12 @@ Books
 
 ..
 
-    [TDD-Python] Harry Percival,
-    `Test-Driven Web Development with Python`_, O'Reilly, June 2014,
-    `Appendix E: BDD <https://chimera.labs.oreilly.com/books/1234000000754/ape.html>`_
-    (covers behave)
+    Harry Percival,
+    `Test-Driven Development with Python`_, 2nd Edition, O'Reilly, August 2017
+    (focuses on Web development with Django, covers Behave in Appendix E: BDD)
 
-.. _`Test-Driven Web Development with Python`: https://chimera.labs.oreilly.com/books/1234000000754
+.. _Test-Driven Development with Python:
+    https://www.oreilly.com/library/view/test-driven-development-with/9781491958698/
 
 
 Presentation Videos


### PR DESCRIPTION
Updates the link to point to the 2nd Edition of Harry's book.

Note: [3rd Edition (2025)](https://www.oreilly.com/library/view/test-driven-development-with/9781098148706/) appears to be dropping Behave from the Appendix.

The content as listed on the O'Reilly website is not final yet, though. The new edition is scheduled for publication in July next year.