### PR TITLE
FEATURE: Force regex-matched arguments to be named

### DIFF
--- a/behave/matchers.py
+++ b/behave/matchers.py
@@ -532,8 +532,9 @@ class RegexMatcher(Matcher):
         for index, group in enumerate(matched.groups()):
             index += 1
             name = group_index.get(index, None)
-            args.append(Argument(matched.start(index), matched.end(index),
-                                 group, group, name))
+            if name is not None:
+                args.append(Argument(matched.start(index), matched.end(index),
+                                     group, group, name))
 
         return args
 


### PR DESCRIPTION
Hi!

In my step matchers that are backed with `re`, I name all arguments explicitly, i.e. `(?P<myarg>\w+)`.

It is consistent with match naming with the other matchers (`{myarg}`), and I don’t have to worry about the order of the arguments in the callback for the matcher.

And in the case when many optional arguments are to be matched, the current version of the regex matcher in Behave forces me to use the uncapture sequence a lot, for example:

```python
use_step_matcher("re")
@given(
  r"A file named (?P<filename>)"
  r"(?: with owner (?P<owner>\w+))?" 
  r"(?: with group (?P<group>\w+))?" 
  r"(?: with mask (?P<mask>\d+))?" 
[…]
)
def given_a_file(context: Context, filename: str, owner: str, group: str, mask: str):
  pass
```

Removing the `?:` sequences in the above would lead to an error similar to:

```
TypeError: run() got multiple values for argument 'filename'
```

With the present patch, only arguments named explicitly using the `?P<argument>` construct would be passed to the handler, simplifying the code and making it more readable:

```python
use_step_matcher("re")
@given(
  r"A file named (?P<filename>)"
  r"( with owner (?P<owner>\w+))?" 
  r"( with group (?P<group>\w+))?" 
  r"( with mask (?P<mask>\d+))?" 
[…]
)
def given_a_file(context: Context, filename: str, owner: str, group: str, mask: str):
  pass
```

Tell me what you think, HTH!