### PR TITLE
fix - model.py table - make line optional

### DIFF
--- a/behave/model.py
+++ b/behave/model.py
@@ -2023,7 +2023,7 @@ class Table(Replayable):
 
         if rows:
             for index, row in enumerate(rows):
-                self.add_row(row, line+index+1)
+                self.add_row(row, self.line+index+1)
 
     def clear(self, headings=None, keep_headings=True):
         if keep_headings and not headings:

--- a/behave/model.py
+++ b/behave/model.py
@@ -2023,7 +2023,7 @@ class Table(Replayable):
 
         if rows:
             for index, row in enumerate(rows):
-                self.add_row(row, self.line+index+1)
+                self.add_row(row, self.line + index + 1)
 
     def clear(self, headings=None, keep_headings=True):
         if keep_headings and not headings:


### PR DESCRIPTION
This is a very minor issue, introduced in e468869932b8edd889c5eb9c25ec77e25ea2f7bc, since the optional param has default `None` and when unset it causes the exception `TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'`.

I doubt others will run into this, but posting this PR just as courtesy.
