### PR TITLE
chore: fixed links in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,10 +105,10 @@ we recommend the `tutorial`_ and then the `feature testing language`_ and
 `api`_ references.
 
 
-.. _`Install *behave*.`: https://behave.readthedocs.io/en/stable/install.html
-.. _`tutorial`: https://behave.readthedocs.io/en/stable/tutorial.html#features
-.. _`feature testing language`: https://behave.readthedocs.io/en/stable/gherkin.html
-.. _`api`: https://behave.readthedocs.io/en/stable/api.html
+.. _`Install *behave*.`: https://behave.readthedocs.io/en/stable/install/
+.. _`tutorial`: https://behave.readthedocs.io/en/stable/tutorial/
+.. _`feature testing language`: https://behave.readthedocs.io/en/stable/gherkin/
+.. _`api`: https://behave.readthedocs.io/en/stable/api/
 
 
 More Information


### PR DESCRIPTION
Updated all but one link, the one for the PDF of the docs. Couldn't seem to find if it was still available, i.e. didn't show up as an option to download as PDF via the ReadTheDocs (see attached image :cat:). If it exists please add inside the PR and i'll do a quick commit.

<img width="341" height="271" alt="image" src="https://github.com/user-attachments/assets/2a58f2ce-1feb-4cfc-976e-ccd6f3041c62" />
