### PR TITLE
fix: Configuration argument `verbose` unused

### DIFF
--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -835,7 +835,7 @@ class Configuration(object):
         """
         (Re-)Init this configuration object.
         """
-        self.defaults = self.make_defaults(**kwargs)
+        self.defaults = self.make_defaults(verbose=verbose, **kwargs)
         self.version = None
         self.capture = None
         self.capture_stdout = None


### PR DESCRIPTION
Configuration is not applying the verbose it receives as argument.

The issue is that the `init` method receives `verbose` as a separate
argument from all others and is not passing it to `make_default`. The
defaults are then passed to the `ArgumentParser`, which would be missing
the verbose initially passed to `Configuration`, and where verbose has
action="store_true", making it default to False.

This patch also stores `verbose` in the defaults used by the arg parser.