### PR TITLE
fix: make _StepDecorator a callable stub

### DIFF
--- a/behave/step_registry.py
+++ b/behave/step_registry.py
@@ -212,10 +212,11 @@ class StepRegistry(object):
 # -- STEP-DECORATOR PLACEHOLDERS (setup at end of this module):
 class _StepDecorator:
     def __call__(self, *args, **kwargs):
-       def decorator(func):
-           return func(*args, **kwargs)
+        def decorator(func):
+            # Placeholder: no-op decorator, just return the original function.
+            return func
 
-       return decorator
+        return decorator
 
 
 registry = StepRegistry()


### PR DESCRIPTION
Implements workaround in [#1292](https://github.com/behave/behave/issues/1292#issuecomment-3694973210) before explicitly supporting type checking.

Type checkers like `pyright` and `ty` use static analysis to determine types (instead of dynamic/run-time analysis). Since the behave decorators are declared with the [`_StepDecorator` stub (placeholder)](https://github.com/behave/behave/blob/d659aab9c6510f021ab18849c6fb4f2ed15ea6a4/behave/step_registry.py#L219-L228) and then [replaced at runtime](https://github.com/behave/behave/blob/d659aab9c6510f021ab18849c6fb4f2ed15ea6a4/behave/step_registry.py#L242), both `pyright` and `ty` report that the decorator is not callable.

```shell
(venv) /tmp/behave-proposal $ ty check
error[call-non-callable]: Object of type `_StepDecorator` is not callable
 --> test.py:3:2
  |
1 | from behave import given
2 |
3 | @given("something")  # <-- type check error
  |  ^^^^^^^^^^^^^^^^^^
4 | def do_something(context):
5 |     pass
  |
info: rule `call-non-callable` is enabled by default

Found 1 diagnostic

(venv) /tmp/behave-proposal $ npx pyright
/tmp/behave-proposal/test.py
  /tmp/behave-proposal/test.py:3:2 - error: Object of type "_StepDecorator" is not callable
    Attribute "__call__" is unknown (reportCallIssue)
1 error, 0 warnings, 0 informations
```

We can correct this by changing the stub to be a callable stub. The same commands with this branch are successful:

```shell
(venv) /tmp/behave-proposal $ ty check
All checks passed!

(venv) /tmp/behave-proposal $ npx pyright
0 errors, 0 warnings, 0 informations
```