### PR TITLE
Fixed incorrect config reference in Context causing cleanup_error's

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ FIXED:
 
 * Include changes from ``behave v1.3.1`` (#1255, #1239)
 * issue #1028: use unittest.mock instead of mock (submitted by: pgajdos)
+* pull #1297: Context._pop(): Use internal config reference to avoid cleanup-errors if "context.config" is masked (provided by: wiebren)
 
 DOCUMENTATION:
 

--- a/behave/runner.py
+++ b/behave/runner.py
@@ -327,7 +327,7 @@ class Context:
         #    capture_sink = self._runner.capture_sink
 
         try:
-            if self.config.should_capture_hooks():
+            if self._config.should_capture_hooks():
                 layer = self._stack[0].get("@layer", None)
                 name = "{}.cleanup".format(layer or "")
                 show_on_success = any_hook.show_cleanup_on_success

--- a/tests/unit/test_runner_context.py
+++ b/tests/unit/test_runner_context.py
@@ -98,13 +98,17 @@ class TestContext:
         """
         context = self.make_context()
 
+        # -- SIMULATE: User masks root attributes, like in a "before_all" hook.
         with context.use_with_user_mode():
-            for key in context._root.keys():
-                if key[0] != '@':
-                    context.__setattr__(key, False)
+            for key in list(context._root.keys()):
+                if key[0] != "@":
+                    setattr(context, key, False)
 
-        # -- SHOULD-NOT-RAISE:
-        context._pop()
+        # -- SHOULD-NOT-RAISE: Cleanups must use the real config object.
+        with scoped_context_layer(context, "scenario"):
+            pass
+
+        assert len(context._stack) == 1
 
 
 class TestContext2(unittest.TestCase):

--- a/tests/unit/test_runner_context.py
+++ b/tests/unit/test_runner_context.py
@@ -103,6 +103,7 @@ class TestContext:
                 if key[0] != '@':
                     context.__setattr__(key, False)
 
+        # -- SHOULD-NOT-RAISE:
         context._pop()
 
 

--- a/tests/unit/test_runner_context.py
+++ b/tests/unit/test_runner_context.py
@@ -88,6 +88,23 @@ class TestContext:
         context._push()
         assert "thing" in context
 
+    def test_context_root_override_should_not_break_context(self):
+        """
+        When a user overrides a root attribute of the context, like "config",
+        then popping the context layer still works.
+
+        The cleanup path has to reach the real config object, not whatever the
+        user happens to have stored under that name.
+        """
+        context = self.make_context()
+
+        with context.use_with_user_mode():
+            for key in context._root.keys():
+                if key[0] != '@':
+                    context.__setattr__(key, False)
+
+        context._pop()
+
 
 class TestContext2(unittest.TestCase):
     # pylint: disable=invalid-name, protected-access, no-self-use


### PR DESCRIPTION
Fixed incorrect `config` reference in `Context` causing cleanup_error's