### PR TITLE
trim Py2-compatible class syntax

### DIFF
--- a/behave/_stepimport.py
+++ b/behave/_stepimport.py
@@ -36,7 +36,7 @@ def setup_api_with_matcher_functions(module, step_matcher_factory):
     module.register_type = step_matcher_factory.register_type
 
 
-class SimpleStepContainer(object):
+class SimpleStepContainer:
     def __init__(self, step_registry=None):
         if step_registry is None:
             step_registry = StepRegistry()
@@ -48,7 +48,7 @@ class SimpleStepContainer(object):
 # -----------------------------------------------------------------------------
 # FAKE MODULE CLASSES: For step imports
 # -----------------------------------------------------------------------------
-# class FakeModule(object):
+# class FakeModule:
 class FakeModule(ModuleType):
     ensure_fake = True
 
@@ -123,7 +123,7 @@ class BehaveModule(FakeModule):
         self.__package__ = None
 
 
-class StepImportModuleContext(object):
+class StepImportModuleContext:
 
     def __init__(self, step_container):
         self.step_registry = step_container.step_registry

--- a/behave/_types.py
+++ b/behave/_types.py
@@ -5,7 +5,7 @@ import types
 # -----------------------------------------------------------------------------
 # BASIC TYPES:
 # -----------------------------------------------------------------------------
-class Unknown(object):
+class Unknown:
     """
     Placeholder for unknown/missing information, distinguishable from None.
 

--- a/behave/async_step.py
+++ b/behave/async_step.py
@@ -258,7 +258,7 @@ class AsyncStepFunction(AsyncFunction):
 # -----------------------------------------------------------------------------
 # ASYNC STEP UTILITY CLASSES:
 # -----------------------------------------------------------------------------
-class AsyncContext(object):
+class AsyncContext:
     # pylint: disable=line-too-long
     """Provides a context object for "async steps" to keep track:
 

--- a/behave/capture.py
+++ b/behave/capture.py
@@ -38,7 +38,7 @@ def add_text_to(value, more_text, separator="\n"):
 # -----------------------------------------------------------------------------
 # CAPTURED CLASSES as VALUE OBJECTS
 # -----------------------------------------------------------------------------
-class ICaptured(object):
+class ICaptured:
     """MARKER-CLASS for any Captured class (as value object)."""
 
 
@@ -405,7 +405,7 @@ class ManyCaptured(ICaptured):
 # CAPTURED HELPER CLASSES
 # -----------------------------------------------------------------------------
 # XXX_MAYBE: use_any_status=True
-class CapturedQuery(object):
+class CapturedQuery:
     @staticmethod
     def select_by_status(captured, use_any_status=False):
         if captured.failed or use_any_status:
@@ -426,7 +426,7 @@ class CapturedQuery(object):
 # -----------------------------------------------------------------------------
 # CAPTURE SINKS:
 # -----------------------------------------------------------------------------
-class ICaptureSink(object):
+class ICaptureSink:
     def process_captured(self, captured):
         raise NotImplementedError()
 
@@ -496,7 +496,7 @@ class CaptureSink2Print(ICaptureSink):
 # -----------------------------------------------------------------------------
 # CAPTURE CONTROLLERS:
 # -----------------------------------------------------------------------------
-class CaptureBookmark(object):
+class CaptureBookmark:
     """Provides a reference point in time what was captured until now."""
     __slots__ = ("offset_stdout", "offset_stderr", "offset_log")
 
@@ -551,7 +551,7 @@ class CaptureBookmark(object):
 
 
 
-class CaptureController(object):
+class CaptureController:
     """Simplifies the lifecycle to capture output from various sources."""
 
     def __init__(self, config, name=None):

--- a/behave/compat/collections.py
+++ b/behave/compat/collections.py
@@ -20,7 +20,7 @@ except ImportError:     # pragma: no cover
 try:
     from collections import UserDict
 except ImportError:      # pragma: no cover
-    class UserDict(object):
+    class UserDict:
         """Emulate collections.UserDict class in python3."""
         def __init__(self, data=None):
             if data is None:

--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -61,7 +61,7 @@ DEFAULT_RUNNER_CLASS_NAME = "behave.runner:Runner"
 # -----------------------------------------------------------------------------
 # CONFIGURATION DATA TYPES and TYPE CONVERTERS:
 # -----------------------------------------------------------------------------
-class LogLevel(object):
+class LogLevel:
     names = [
         "NOTSET", "CRITICAL", "FATAL", "ERROR",
         "WARNING", "WARN", "INFO", "DEBUG",
@@ -749,7 +749,7 @@ def setup_config_file_parser():
         parser.add_argument(*fixed, **keywords)
     return parser
 
-class Configuration(object):
+class Configuration:
     """
     Configuration object for behave and behave runners.
 

--- a/behave/cucumber_expression.py
+++ b/behave/cucumber_expression.py
@@ -28,7 +28,7 @@ from parse_type import TypeBuilder as _TypeBuilder
 # -----------------------------------------------------------------------------
 # STEP-MATCHER SUPPORT CLASSES FOR: CucumberExpressions
 # -----------------------------------------------------------------------------
-class TypeRegistry4ParameterType(object):
+class TypeRegistry4ParameterType:
     """
     Provides adapter to :class:`ParameterTypeRegistry`.
 

--- a/behave/exception_util.py
+++ b/behave/exception_util.py
@@ -3,7 +3,7 @@ import traceback
 from behave._types import Unknown, require_type
 
 
-class ExceptionUtil(object):
+class ExceptionUtil:
     """
     Provides a utility class for accessing/modifying exception information.
 

--- a/behave/formatter/_registry.py
+++ b/behave/formatter/_registry.py
@@ -9,7 +9,7 @@ from behave.exception import ClassNotFoundError
 # -----------------------------------------------------------------------------
 # FORMATTER BAD CASES:
 # -----------------------------------------------------------------------------
-class BadFormatterClass(object):
+class BadFormatterClass:
     """Placeholder class if a formatter class is invalid."""
     def __init__(self, name, formatter_class):
         self.name = name

--- a/behave/formatter/api.py
+++ b/behave/formatter/api.py
@@ -6,7 +6,7 @@ Defines interface(s) for formatter classes.
 # -----------------------------------------------------------------------------
 # FORMATTER INTERFACE:
 # -----------------------------------------------------------------------------
-class IFormatter(object):
+class IFormatter:
     """
     Provides the main interface for formatter classes.
 

--- a/behave/formatter/base.py
+++ b/behave/formatter/base.py
@@ -10,7 +10,7 @@ from behave.textutil import (
 # -----------------------------------------------------------------------------
 # FORMATTER HELPER CLASSES
 # -----------------------------------------------------------------------------
-class StreamOpener(object):
+class StreamOpener:
     """Provides a transport vehicle to open the formatter output stream
     when the formatter needs it.
     In addition, it provides the formatter with more control:

--- a/behave/formatter/pretty.py
+++ b/behave/formatter/pretty.py
@@ -35,12 +35,12 @@ def get_terminal_size():
 # -----------------------------------------------------------------------------
 # COLORING SUPPORT:
 # -----------------------------------------------------------------------------
-class MonochromeFormat(object):
+class MonochromeFormat:
     def text(self, text):   # pylint: disable=no-self-use
         assert isinstance(text, str)
         return text
 
-class ColorFormat(object):
+class ColorFormat:
     def __init__(self, status):
         self.status = status
 

--- a/behave/formatter/sphinx_steps.py
+++ b/behave/formatter/sphinx_steps.py
@@ -31,7 +31,7 @@ except ImportError:
 # -----------------------------------------------------------------------------
 # HELPER CLASS:
 # -----------------------------------------------------------------------------
-class StepsModule(object):
+class StepsModule:
     """
     Value object to keep track of step definitions that belong to same module.
     """
@@ -86,7 +86,7 @@ class StepsModule(object):
 # -----------------------------------------------------------------------------
 # CLASS: SphinxStepsDocumentGenerator
 # -----------------------------------------------------------------------------
-class SphinxStepsDocumentGenerator(object):
+class SphinxStepsDocumentGenerator:
     """
     Provides document generator class that generates Sphinx-based
     documentation for step definitions. The primary purpose is to:

--- a/behave/formatter/sphinx_util.py
+++ b/behave/formatter/sphinx_util.py
@@ -9,7 +9,7 @@ from behave.textutil import compute_words_maxsize, text as _text
 # -----------------------------------------------------------------------------
 # SPHINX OUTPUT GENERATION FUNCTIONS:
 # -----------------------------------------------------------------------------
-class DocumentWriter(object):
+class DocumentWriter:
     """
     Provides a simple "ReStructured Text Writer" to generate
     Sphinx-based documentation.

--- a/behave/importer.py
+++ b/behave/importer.py
@@ -61,7 +61,7 @@ def load_module(module_name):
         raise ModuleNotFoundError(msg)
 
 
-class LazyObject(object):
+class LazyObject:
     """Provides a placeholder for an class/object that should be loaded lazily.
 
     It stores the module-name, object-name/class-name and

--- a/behave/json_parser.py
+++ b/behave/json_parser.py
@@ -43,7 +43,7 @@ def parse(json_filename, encoding="UTF-8"):
 # ----------------------------------------------------------------------------
 # CLASSES:
 # ----------------------------------------------------------------------------
-class JsonParser(object):
+class JsonParser:
 
     def __init__(self):
         self.current_scenario_outline = None

--- a/behave/log_capture.py
+++ b/behave/log_capture.py
@@ -11,7 +11,7 @@ from behave.log_config import (
 # -----------------------------------------------------------------------------
 # CLASSES
 # -----------------------------------------------------------------------------
-class RecordFilter(object):
+class RecordFilter:
     """Implement logging record filtering as per the configuration
     --logging-filter option.
     """

--- a/behave/log_config.py
+++ b/behave/log_config.py
@@ -22,7 +22,7 @@ _PYTHON_VERSION = sys.version_info[:2]
 # -----------------------------------------------------------------------------
 # CLASSES
 # -----------------------------------------------------------------------------
-class LoggingConfigurator(object):
+class LoggingConfigurator:
     DEFAULT_LEVEL = logging.INFO
     DEFAULT_FORMAT_STYLE = '%'
 

--- a/behave/matchers.py
+++ b/behave/matchers.py
@@ -186,7 +186,7 @@ class TypeRegistryNotSupported():
 # -----------------------------------------------------------------------------
 # SECTION: Step Matchers
 # -----------------------------------------------------------------------------
-class Matcher(object):
+class Matcher:
     """
     Provides an abstract base class for step-matcher classes.
 
@@ -576,7 +576,7 @@ class CucumberRegexMatcher(RegexMatcher):
 # -----------------------------------------------------------------------------
 # STEP MATCHER FACTORY (for public API)
 # -----------------------------------------------------------------------------
-class StepMatcherFactory(object):
+class StepMatcherFactory:
     """
     This class provides functionality for the public API of step-matchers.
 

--- a/behave/model.py
+++ b/behave/model.py
@@ -1280,7 +1280,7 @@ class Scenario(TagAndStatusStatement, Replayable):
         return failed
 
 
-class ScenarioOutlineBuilder(object):
+class ScenarioOutlineBuilder:
     """Helper class to use a ScenarioOutline as a template and
     build its scenarios (as template instances).
     """
@@ -1337,7 +1337,7 @@ class ScenarioOutlineBuilder(object):
         params["examples.name"] = examples_name
         scenario_name = self.render_template(outline_name, row, params)
 
-        class Data(object):
+        class Data:
             def __init__(self, name, index):
                 self.name = name
                 self.index = index
@@ -2281,7 +2281,7 @@ class Table(Replayable):
         return table
 
 
-class Row(object):
+class Row:
     """One row of a `table`_ parsed from a *feature file*.
 
     Row data is accessible using a number of methods:

--- a/behave/model_core.py
+++ b/behave/model_core.py
@@ -16,7 +16,7 @@ from behave.model_type import (
 # -----------------------------------------------------------------------------
 # ABSTRACT MODEL CLASSES (and concepts):
 # -----------------------------------------------------------------------------
-class BasicStatement(object):
+class BasicStatement:
     STORE_CAPTURED_ON_SUCCESS = CAPTURE_SINK_STORE_CAPTURED_ON_SUCCESS
 
     def __init__(self, filename, line, keyword, name):
@@ -210,7 +210,7 @@ class TagAndStatusStatement(BasicStatement):
         raise NotImplementedError()
 
 
-class Replayable(object):
+class Replayable:
     type = None
 
     def replay(self, formatter):

--- a/behave/model_describe.py
+++ b/behave/model_describe.py
@@ -30,7 +30,7 @@ def escape_triple_quotes(text):
 # -----------------------------------------------------------------------------
 # CLASS:
 # -----------------------------------------------------------------------------
-class ModelDescriptor(object):
+class ModelDescriptor:
 
     @staticmethod
     def describe_table(table, indentation=None):

--- a/behave/model_type.py
+++ b/behave/model_type.py
@@ -212,7 +212,7 @@ class Status(Enum):
         return enum_value
 
 
-class ScenarioStatus(object):
+class ScenarioStatus:
     """
     Utility class that computes the Scenario status from one of its steps.
     """
@@ -242,7 +242,7 @@ class ScenarioStatus(object):
         return cls.from_step_status(step.status, dry_run=dry_run)
 
 
-class OuterStatus(object):
+class OuterStatus:
     """
     Used for feature(s) and rule(s) to derive their status
     from one of its contained model-elements (like: scenarios).
@@ -268,7 +268,7 @@ class OuterStatus(object):
 
 # @total_ordering
 # MAYBE: class FileLocation(unicode):
-class FileLocation(object):
+class FileLocation:
     """
     Provides a value object for file location objects.
     A file location consists of:
@@ -397,7 +397,7 @@ class FileLocation(object):
 
 
 
-class Argument(object):
+class Argument:
     """An argument found in a *feature file* step name.
 
     The attributes are:

--- a/behave/model_visitor.py
+++ b/behave/model_visitor.py
@@ -9,7 +9,7 @@ from behave._types import require_type
 from behave.model import Feature, Rule, ScenarioOutline, Scenario, Step
 
 
-class IModelVisitor(object):
+class IModelVisitor:
     """Interface that must be implemented by a ``ModelVisitor`` class.
     Each ``ModelVisitor`` can override and implement a subset or
     all visitor methods.

--- a/behave/parser.py
+++ b/behave/parser.py
@@ -218,7 +218,7 @@ class State(Enum):
     TABLE = 9
 
 
-class Parser(object):
+class Parser:
     """Feature file parser for behave."""
     # pylint: disable=too-many-instance-attributes
     STRIP_STEPS_WITH_TRAILING_COLON = BEHAVE_STRIP_STEPS_WITH_TRAILING_COLON

--- a/behave/python_feature.py
+++ b/behave/python_feature.py
@@ -15,7 +15,7 @@ PYTHON_VERSION = sys.version_info[:2]
 # -----------------------------------------------------------------------------
 # CLASSES:
 # -----------------------------------------------------------------------------
-class PythonFeature(object):
+class PythonFeature:
 
     @staticmethod
     def has_async_function():

--- a/behave/reporter/base.py
+++ b/behave/reporter/base.py
@@ -1,7 +1,7 @@
 from behave.model_type import Status
 
 
-class Reporter(object):
+class Reporter:
     """
     Base class for all reporters.
     A reporter provides an extension point (variant point) for the runner logic.

--- a/behave/reporter/junit.py
+++ b/behave/reporter/junit.py
@@ -162,7 +162,7 @@ if hasattr(ElementTree, '_serialize'):
     ElementTree._serialize_xml = ElementTree._serialize['xml'] = _serialize_xml3
 
 
-class FeatureReportData(object):
+class FeatureReportData:
     """
     Provides value object to collect JUnit report data from a Feature.
     """

--- a/behave/runner.py
+++ b/behave/runner.py
@@ -58,7 +58,7 @@ class ContextMode(Enum):
     USER = 2
 
 
-class Context(object):
+class Context:
     """Hold contextual information during the running of tests.
 
     This object is a place to store information related to the tests you're
@@ -644,7 +644,7 @@ def path_getrootdir(path):
     return os.path.sep
 
 
-class ModelRunner(object):
+class ModelRunner:
     """Test runner for a behave model (features).
     Provides the core functionality of a test runner and
     the functional API needed by model elements.

--- a/behave/runner_plugin.py
+++ b/behave/runner_plugin.py
@@ -24,7 +24,7 @@ from behave.importer import load_module, make_scoped_class_name, parse_scoped_na
 from behave._types import Unknown
 
 
-class RunnerPlugin(object):
+class RunnerPlugin:
     """Extension point to load a runner_class and create its runner:
 
     * create a runner by using its scoped-class-name

--- a/behave/runner_util.py
+++ b/behave/runner_util.py
@@ -27,7 +27,7 @@ from behave.textutil import ensure_stream_with_encoder
 # -----------------------------------------------------------------------------
 # CLASS: FileLocationParser
 # -----------------------------------------------------------------------------
-class FileLocationParser(object):
+class FileLocationParser:
     pattern = re.compile(r"^\s*(?P<filename>.*):(?P<line>\d+)\s*$", re.UNICODE)
 
     @classmethod
@@ -51,7 +51,7 @@ class FileLocationParser(object):
 # -----------------------------------------------------------------------------
 # CLASSES:
 # -----------------------------------------------------------------------------
-class FeatureLineDatabase(object):
+class FeatureLineDatabase:
     """Helper class that supports select-by-location mechanism (FileLocation)
     within a feature file by storing the feature line numbers for each entity.
 
@@ -141,7 +141,7 @@ class FeatureLineDatabase(object):
 
 
 
-class FeatureScenarioLocationCollector(object):
+class FeatureScenarioLocationCollector:
     """
     Collects FileLocation objects for a feature.
     This is used to select a subset of scenarios in a feature that should run.
@@ -372,7 +372,7 @@ class FeatureScenarioLocationCollector2(FeatureScenarioLocationCollector):
         return selected_scenarios
 
 
-class FeatureListParser(object):
+class FeatureListParser:
     """
     Read textual file, ala '@features.txt'. This file contains:
 
@@ -434,7 +434,7 @@ class FeatureListParser(object):
             return cls.parse(contents, here)
 
 
-class PathManager(object):
+class PathManager:
     """Context manager to add paths to sys.path (python search path)
     within a scope.
     """

--- a/behave/step_registry.py
+++ b/behave/step_registry.py
@@ -31,7 +31,7 @@ class AmbiguousStep(ValueError):
     pass
 
 
-class BadStepDefinitionCollector(object):
+class BadStepDefinitionCollector:
     BAD_STEP_DEFINITION_MESSAGE = """\
 BAD-STEP-DEFINITION: {step}
   LOCATION: {step_location}
@@ -77,7 +77,7 @@ class BadStepDefinitionErrorHandler(BadStepDefinitionCollector):
         raise error
 
 
-class StepRegistry(object):
+class StepRegistry:
     BAD_STEP_DEFINITION_HANDLER_CLASS = BadStepDefinitionErrorHandler
     RAISE_ERROR_ON_BAD_STEP_DEFINITION = False
 

--- a/behave/summary.py
+++ b/behave/summary.py
@@ -365,7 +365,7 @@ class HookErrorCounts(Counter):
     #     return the_sum
 
 
-class SummaryCounts(object):
+class SummaryCounts:
     """Composite value object that contains the counter objects related to:
 
     * features

--- a/behave/tag_matcher.py
+++ b/behave/tag_matcher.py
@@ -15,7 +15,7 @@ from .model_core import TagAndStatusStatement
 # -----------------------------------------------------------------------------
 # VALUE OBJECT CLASSES FOR: Active-Tag Value Providers
 # -----------------------------------------------------------------------------
-class ValueObject(object):
+class ValueObject:
     """Value object for active-tags that holds the current value for
     one activate-tag category and its comparison function.
 
@@ -136,7 +136,7 @@ class BoolValueObject(ValueObject):
 # -----------------------------------------------------------------------------
 # CLASSES FOR: Active-Tags and ActiveTagMatchers
 # -----------------------------------------------------------------------------
-class TagMatcher(object):
+class TagMatcher:
     """Abstract base class that defines the TagMatcher protocol."""
 
     def should_skip(self, model_element, use_inherited=False):
@@ -255,7 +255,7 @@ class ActiveTagMatcher(TagMatcher):
 
     .. code-block:: python
 
-        class MyValueProvider(object):
+        class MyValueProvider:
             def get(self, category_name, default=None):
                 ...
                 return category_value   # OR: default, if category is unknown.
@@ -536,7 +536,7 @@ class CompositeTagMatcher(TagMatcher):
 # -----------------------------------------------------------------------------
 # ACTIVE TAG VALUE PROVIDER CLASSES:
 # -----------------------------------------------------------------------------
-class IActiveTagValueProvider(object):
+class IActiveTagValueProvider:
     """Protocol/Interface for active-tag value providers."""
 
     def get(self, category, default=None):

--- a/behave/userdata.py
+++ b/behave/userdata.py
@@ -123,7 +123,7 @@ class UserData(dict):
         return data
 
 
-class UserDataNamespace(object):
+class UserDataNamespace:
     """Provides a light-weight dictview to the user data that allows you
     to access all params in a namespace, that use "{namespace}.*" names.
 

--- a/behave4cmd0/command_shell.py
+++ b/behave4cmd0/command_shell.py
@@ -43,7 +43,7 @@ def get_behave_cmd(search_path=None):
 # -----------------------------------------------------------------------------
 # CLASSES:
 # -----------------------------------------------------------------------------
-class CommandResult(object):
+class CommandResult:
     """
     ValueObject to store the results of a subprocess command call.
     """
@@ -80,7 +80,7 @@ class CommandResult(object):
         self._output = None
 
 
-class Command(object):
+class Command:
     """
     Helper class to run commands as subprocess,
     collect their output and subprocess returncode.

--- a/behave4cmd0/command_shell_proc.py
+++ b/behave4cmd0/command_shell_proc.py
@@ -19,7 +19,7 @@ def posixpath_normpath(filename):
 # -----------------------------------------------------------------------------
 # LINE PROCESSORS:
 # -----------------------------------------------------------------------------
-class LineProcessor(object):
+class LineProcessor:
     """Function-like object that may perform text-line transformations."""
     def __init__(self, marker=None):
         self.marker = marker
@@ -102,7 +102,7 @@ class ExceptionWithPathNormalizer(LineProcessor):
 # -----------------------------------------------------------------------------
 # COMMAND OUTPUT PROCESSORS:
 # -----------------------------------------------------------------------------
-class CommandPostProcessor(object):
+class CommandPostProcessor:
     """Syntactic sugar to mark a command post-processor."""
 
 

--- a/behave4cmd0/environment_fixtures.py
+++ b/behave4cmd0/environment_fixtures.py
@@ -20,7 +20,7 @@ def get_scope_name_from_context(ctx):
     return "testrun"
 
 
-class ScopedEnvironment(object):
+class ScopedEnvironment:
     """Store current environment variables and restore them afterwards."""
     def __init__(self, env=None):
         if env is None:

--- a/behave4cmd0/log_steps.py
+++ b/behave4cmd0/log_steps.py
@@ -116,7 +116,7 @@ def make_log_record_output(category, level, message,
     return formatter.format(record)
 
 
-class LogRecordTable(object):
+class LogRecordTable:
 
     @classmethod
     def make_output_for_row(cls, row, format=None, datefmt=None, **kwargs):

--- a/behave4cmd0/textutil.py
+++ b/behave4cmd0/textutil.py
@@ -16,7 +16,7 @@ DEBUG = False
 # -----------------------------------------------------------------------------
 # CLASS: TextProxy
 # -----------------------------------------------------------------------------
-# class TextProxy(object):
+# class TextProxy:
 #     """
 #     Simplifies conversion between (Unicode) string and its byte representation.
 #     Provides a ValueObject to store a string or its byte representation.

--- a/bin/behave.step_durations.py
+++ b/bin/behave.step_durations.py
@@ -27,7 +27,7 @@ VERSION = "0.2.0"
 # ----------------------------------------------------------------------------
 # FUNCTIONS:
 # ----------------------------------------------------------------------------
-class StepDurationData(object):
+class StepDurationData:
     def __init__(self, step=None):
         self.step_name = None
         self.min_duration = sys.maxint
@@ -53,7 +53,7 @@ class StepDurationData(object):
         self.durations.append(step.duration)
 
 
-class BehaveDurationData(object):
+class BehaveDurationData:
     def __init__(self):
         self.step_registry = {}
         self.all_steps = []

--- a/bin/make_localpi.py
+++ b/bin/make_localpi.py
@@ -49,7 +49,7 @@ __license__ = "BSD"
 __copyright__ = "(c) 2013 by Jens Engel"
 
 
-class Package(object):
+class Package:
     """
     Package entity that keeps track of:
       * one or more versions of this package

--- a/bin/toxcmd.py
+++ b/bin/toxcmd.py
@@ -194,7 +194,7 @@ def discover_commands():
     return commands
 
 
-class Command(object):
+class Command:
     def __init__(self, name, func):
         assert isinstance(name, str)
         assert callable(func)

--- a/bin/toxcmd3.py
+++ b/bin/toxcmd3.py
@@ -198,7 +198,7 @@ def discover_commands():
     return commands
 
 
-class Command(object):
+class Command:
     def __init__(self, name, func):
         assert isinstance(name, str)
         assert isinstance(func, collections.Callable)

--- a/docs/philosophy.rst
+++ b/docs/philosophy.rst
@@ -163,7 +163,7 @@ For instance as unit tests, the above examples might become:
 
 .. code-block:: python
 
- class TestList(object):
+ class TestList:
     def test_empty_list_is_false(self):
         list = []
         assertEqual(bool(list), False)
@@ -180,7 +180,7 @@ Sometimes the difference between the context, events and outcomes is made more e
 
 .. code-block:: python
 
- class TestWindow(object):
+ class TestWindow:
     def test_window_close(self):
         # Given
         window = gui.Window("My Window")

--- a/features/formatter.help.feature
+++ b/features/formatter.help.feature
@@ -87,7 +87,7 @@ Feature: Help Formatter
       Given an empty file named "behave4me/__init__.py"
       And a file named "behave4me/bad_formatter.py" with:
         """
-        class InvalidFormatter1(object): pass    # CASE 1: Not a subclass-of Formatter
+        class InvalidFormatter1: pass    # CASE 1: Not a subclass-of Formatter
         InvalidFormatter2 = True                 # CASE 2: Not a class
         """
 

--- a/features/formatter.json.feature
+++ b/features/formatter.json.feature
@@ -251,7 +251,7 @@ Feature: JSON Formatter
           import parse
 
           # -- TYPES AND TYPE CONVERTERS:
-          class Color(object):
+          class Color:
               def __init__(self, color_name):
                   self.name = color_name
 

--- a/features/formatter.steps_code.feature
+++ b/features/formatter.steps_code.feature
@@ -23,7 +23,7 @@ Feature: StepWithCode Formatter
       And an empty file named "example4me/__init__.py"
       And a file named "example4me/calculator.py" with:
           """
-          class Calculator(object):
+          class Calculator:
               def __init__(self, initial_value=0):
                   self.initial_value = initial_value
                   self.result = initial_value
@@ -141,7 +141,7 @@ Feature: StepWithCode Formatter
         from behave import given
         from assertpy import assert_that
 
-        class Person(object):
+        class Person:
             def __init__(self, name, role=None):
                 self.name = name
                 self.role = role

--- a/features/formatter.user_defined.feature
+++ b/features/formatter.user_defined.feature
@@ -47,7 +47,7 @@ Feature: Use a user-defined Formatter
       """
       from behave.formatter.base import Formatter
 
-      class NotAFormatter(object): pass
+      class NotAFormatter: pass
       class SuperFormatter(Formatter):
           name = "super"
           description = "Super-duper formatter."

--- a/features/runner.context_cleanup.feature
+++ b/features/runner.context_cleanup.feature
@@ -48,7 +48,7 @@ Feature: Perform Context.cleanups at the end of a test-run, feature or scenario 
         class SomeError(RuntimeError): pass
 
         # -- CLEANUP FUNCTIONS:
-        class CleanupFuntion(object):
+        class CleanupFuntion:
             def __init__(self, name=None):
                 self.name = name or ""
 

--- a/features/runner.help.feature
+++ b/features/runner.help.feature
@@ -72,7 +72,7 @@ Feature: Runner Help
       Given an empty file named "behave4me/__init__.py"
       And a file named "behave4me/bad_runner.py" with:
         """
-        class InvalidRunner1(object): pass    # CASE 1: Not a subclass-of ITestRunner
+        class InvalidRunner1: pass    # CASE 1: Not a subclass-of ITestRunner
         InvalidRunner2 = True                 # CASE 2: Not a class
         """
 

--- a/features/runner.use_runner_class.feature
+++ b/features/runner.use_runner_class.feature
@@ -106,7 +106,7 @@ Feature: User-provided Test Runner Class (extension-point)
         """
         from behave.runner import Runner as CoreRunner
 
-        class MyRunner2(object):
+        class MyRunner2:
             def __init__(self, config, **kwargs):
                 self.config = config
                 self._runner = CoreRunner(config)
@@ -254,8 +254,8 @@ Feature: User-provided Test Runner Class (extension-point)
         """
         from behave.api.runner import ITestRunner
 
-        class NotRunner1(object): pass
-        class NotRunner2(object):
+        class NotRunner1: pass
+        class NotRunner2:
             run = True
 
         CONSTANT_1 = 42
@@ -363,8 +363,8 @@ Feature: User-provided Test Runner Class (extension-point)
         """
         from behave.api.runner import ITestRunner
 
-        class NotRunner1(object): pass
-        class NotRunner2(object):
+        class NotRunner1: pass
+        class NotRunner2:
             run = True
 
         CONSTANT_1 = 42

--- a/features/step_param.builtin_types.with_float.feature
+++ b/features/step_param.builtin_types.with_float.feature
@@ -29,7 +29,7 @@ Feature: Parse data types in step parameters (type transformation)
     And a file named "features/steps/float_param_steps.py" with:
         """
         from behave import then, step
-        class NotMatched(object): pass
+        class NotMatched: pass
 
         @step('a float param with "{value:g}"')
         def step_float_param_with(context, value):

--- a/features/step_param.builtin_types.with_integer.feature
+++ b/features/step_param.builtin_types.with_integer.feature
@@ -31,7 +31,7 @@ Feature: Parse integer data types in step parameters (type transformation)
         """
         from behave import then, step
 
-        class NotMatched(object): pass
+        class NotMatched: pass
 
         @step('a integer param with "{value:d}"')
         def step_integer_param_with(context, value):

--- a/features/step_param.custom_types.feature
+++ b/features/step_param.custom_types.feature
@@ -24,7 +24,7 @@ Feature: Parse custom data types in step parameters (type transformation)
             return int(text)
 
         register_type(Number=parse_number)
-        class NotMatched(object): pass
+        class NotMatched: pass
 
         @step('a param with "Number:{value:Number}"')
         def step_param_with_number_value(context, value):

--- a/features/steps/behave_model_util.py
+++ b/features/steps/behave_model_util.py
@@ -20,11 +20,11 @@ def convert_model_element_tags(text):
 # -----------------------------------------------------------------------------
 # TEST DOMAIN, FIXTURES, STEP UTILS:
 # -----------------------------------------------------------------------------
-class Model(object):
+class Model:
     def __init__(self, features=None):
         self.features = features or []
 
-class BehaveModelBuilder(object):
+class BehaveModelBuilder:
     REQUIRED_COLUMNS = ["statement", "name"]
     OPTIONAL_COLUMNS = ["tags"]
 

--- a/features/steps/behave_select_files_steps.py
+++ b/features/steps/behave_select_files_steps.py
@@ -30,7 +30,7 @@ from hamcrest import assert_that, equal_to
 # -----------------------------------------------------------------------------
 # STEP UTILS:
 # -----------------------------------------------------------------------------
-class BasicBehaveRunner(object):
+class BasicBehaveRunner:
     def __init__(self, config=None):
         self.config = config
         self.feature_files = []

--- a/features/steps/behave_tag_expression_steps.py
+++ b/features/steps/behave_tag_expression_steps.py
@@ -30,7 +30,7 @@ from hamcrest import assert_that, equal_to
 # -----------------------------------------------------------------------------
 # TEST DOMAIN, FIXTURES, STEP UTILS:
 # -----------------------------------------------------------------------------
-class ModelElement(object):
+class ModelElement:
     def __init__(self, name, tags=None):
         self.name = name
         self.tags = tags or []

--- a/tasks/_dry_run.py
+++ b/tasks/_dry_run.py
@@ -14,7 +14,7 @@ Basic support to use a --dry-run mode w/ invoke tasks.
         ctx.run("rm -rf {}".format(path))
 """
 
-class DryRunContext(object):
+class DryRunContext:
     PREFIX = "DRY-RUN: "
     SCHEMA = "{prefix}{command}"
     SCHEMA_WITH_KWARGS = "{prefix}{command} (with kwargs={kwargs})"

--- a/tests/api/testing_support.py
+++ b/tests/api/testing_support.py
@@ -9,7 +9,7 @@ import time
 # -----------------------------------------------------------------------------
 # TEST SUPPORT:
 # -----------------------------------------------------------------------------
-class StopWatch(object):
+class StopWatch:
     def __init__(self):
         self.start_time = None
         self.duration = None

--- a/tests/api/testing_support_async.py
+++ b/tests/api/testing_support_async.py
@@ -8,7 +8,7 @@ import inspect
 # -----------------------------------------------------------------------------
 # TEST SUPPORT:
 # -----------------------------------------------------------------------------
-class AsyncStepTheory(object):
+class AsyncStepTheory:
     @staticmethod
     def ensure_normal_function(func):
         if hasattr(inspect, "isawaitable"):

--- a/tests/functional/test_active_tags.py
+++ b/tests/functional/test_active_tags.py
@@ -25,7 +25,7 @@ from behave.tag_matcher import ActiveTagMatcher
 # =============================================================================
 # TEST SUITE:
 # =============================================================================
-class TestActiveTags(object):
+class TestActiveTags:
     VALUE_PROVIDER = {
         "foo": "Frank",
         "bar": "Bob",
@@ -148,7 +148,7 @@ class TestActiveTags(object):
         self.check_should_run_with_active_tags(case, expected, tags)
 
 '''
-class Traits4ActiveTagMatcher(object):
+class Traits4ActiveTagMatcher:
     TagMatcher = ActiveTagMatcher
     value_provider = {
         "foo": "alice",
@@ -186,7 +186,7 @@ class Traits4ActiveTagMatcher(object):
 
 
 # -- REQUIRES: pytest
-class TestActiveTagMatcher2(object):
+class TestActiveTagMatcher2:
     TagMatcher = ActiveTagMatcher
     traits = Traits4ActiveTagMatcher
 

--- a/tests/functional/test_capture_on_failed.py
+++ b/tests/functional/test_capture_on_failed.py
@@ -79,7 +79,7 @@ def require_store_captured_on_success_is_false():
 # ----------------------------------------------------------------------------
 # TEST SUITE
 # ----------------------------------------------------------------------------
-class TestCaptureOnStepsRun(object):
+class TestCaptureOnStepsRun:
     """Some additional tests for "Scenario.run()" using pytest."""
 
     def test_captured_with_passing_steps(self):
@@ -162,7 +162,7 @@ ERROR: SomeError: OOPS, FAILED in step2
         assert "OOPS, FAILED in step2" in step2.error_message
 
 
-class TestCaptureOnScenarioRun(object):
+class TestCaptureOnScenarioRun:
 
     def test_captured__good_steps_hooks_and_tags(self):
         require_store_captured_on_success_is_false()
@@ -448,7 +448,7 @@ CALLED: step1
         assert scenario_output.endswith(scenario_expected_2)
 
 
-class TestCaptureOnRuleRun(object):
+class TestCaptureOnRuleRun:
 
     def test_captured__good_hooks_tags_steps(self):
         require_store_captured_on_success_is_false()
@@ -616,7 +616,7 @@ tests.functional.error.SomeError: OOPS, ERROR in bad_fixture_cleanup.two
         assert rule_output.endswith(rule_expected_2)
 
 
-class TestCaptureOnFeatureRun(object):
+class TestCaptureOnFeatureRun:
 
     def test_captured__good_hooks_tags_steps(self):
         require_store_captured_on_success_is_false()

--- a/tests/functional/test_capture_on_success.py
+++ b/tests/functional/test_capture_on_success.py
@@ -79,7 +79,7 @@ def require_store_captured_on_success_is_true():
 # ----------------------------------------------------------------------------
 # TEST SUITE
 # ----------------------------------------------------------------------------
-class TestCaptureOnStepsRun(object):
+class TestCaptureOnStepsRun:
     """Some additional tests for "Scenario.run()" using pytest."""
 
     def test_captured_with_passing_steps(self):
@@ -179,7 +179,7 @@ ERROR: SomeError: OOPS, FAILED in step2
         assert "OOPS, FAILED in step2" in step2.error_message
 
 
-class TestCaptureOnScenarioRun(object):
+class TestCaptureOnScenarioRun:
 
     def test_captured__good_steps_hooks_and_tags(self):
         require_store_captured_on_success_is_true()
@@ -516,7 +516,7 @@ CALLED: step1
         assert scenario_output.endswith(scenario_expected_2)
 
 
-class TestCaptureOnRuleRun(object):
+class TestCaptureOnRuleRun:
 
     def test_captured__good_hooks_tags_steps(self):
         require_store_captured_on_success_is_true()
@@ -715,7 +715,7 @@ tests.functional.error.SomeError: OOPS, ERROR in bad_fixture_cleanup.two
         assert rule_output.endswith(rule_expected_2)
 
 
-class TestCaptureOnFeatureRun(object):
+class TestCaptureOnFeatureRun:
 
     def test_captured__good_hooks_tags_steps(self):
         require_store_captured_on_success_is_true()

--- a/tests/functional/test_tag_expression.py
+++ b/tests/functional/test_tag_expression.py
@@ -14,7 +14,7 @@ import pytest
 # TEST SUITE: TagExpressionParser.parse() and Expression.evaluate(tags) chain
 # -----------------------------------------------------------------------------
 # BASED-ON: cucumber/tag-expressions/python/tests/functional/test_tag_expressions.py
-class TestTagExpression(object):
+class TestTagExpression:
     # correct_test_data = [
     #     ("a and b", "( a and b )"),
     #     ("a or (b)", "( a or b )"),
@@ -140,7 +140,7 @@ class TestTagExpression(object):
 # -----------------------------------------------------------------------------
 # TEST SUITE: TagExpressionParser Extension(s)
 # -----------------------------------------------------------------------------
-class TestTagExpressionExtension(object):
+class TestTagExpressionExtension:
     """Extension of cucumber-tag-expressions to support tag-name-matching."""
 
     @pytest.mark.parametrize("tag_expression_text, expected, tags, case", [

--- a/tests/functional/test_tag_inheritance.py
+++ b/tests/functional/test_tag_inheritance.py
@@ -50,7 +50,7 @@ def assert_no_tags_are_inherited(model_element):
 # -----------------------------------------------------------------------------
 # TEST SUITE
 # -----------------------------------------------------------------------------
-class TestTagInheritance4Feature(object):
+class TestTagInheritance4Feature:
     """A Feature is the outermost model element.
     Therefore, it cannot inherit any features.
     """
@@ -71,7 +71,7 @@ class TestTagInheritance4Feature(object):
         assert_no_tags_are_inherited(this_feature)
 
 
-class TestTagInheritance4Rule(object):
+class TestTagInheritance4Rule:
     def test_no_inherited_tags__without_feature_tags(self):
         text = """
         Feature: F1
@@ -113,7 +113,7 @@ class TestTagInheritance4Rule(object):
         assert_inherited_tags_equal_to(this_rule, ["feature_tag1"])
 
 
-class TestTagInheritance4ScenarioOutline(object):
+class TestTagInheritance4ScenarioOutline:
     def test_no_inherited_tags__without_feature_tags(self):
         text = """
         Feature: F3
@@ -210,7 +210,7 @@ class TestTagInheritance4ScenarioOutline(object):
         assert_inherited_tags_equal_to(this_scenario_outline, ["feature_tag1", "rule_tag1"])
 
 
-class TestTagInheritance4Scenario(object):
+class TestTagInheritance4Scenario:
     def test_no_inherited_tags__without_feature_tags(self):
         text = """
         Feature: F4
@@ -307,7 +307,7 @@ class TestTagInheritance4Scenario(object):
         assert_inherited_tags_equal_to(this_scenario, ["feature_tag1", "rule_tag1"])
 
 
-class TestTagInheritance4ScenarioFromTemplate(object):
+class TestTagInheritance4ScenarioFromTemplate:
     """Test tag inheritance for scenarios from a ScenarioOutline or
     ScenarioTemplate (as alias for ScenarioOutline).
 

--- a/tests/issues/test_issue0336.py
+++ b/tests/issues/test_issue0336.py
@@ -16,7 +16,7 @@ from behave.textutil import text
 import pytest
 
 
-class TestIssue(object):
+class TestIssue:
     # -- USE SAVED TRACEBACK: No need to require Windows platform.
     traceback_bytes = br"""\
 Traceback (most recent call last):

--- a/tests/issues/test_issue0495.py
+++ b/tests/issues/test_issue0495.py
@@ -32,7 +32,7 @@ import pytest
 # def ensure_logging_setup():
 #    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
-class SimpleContext(object):
+class SimpleContext:
     pass
 
 

--- a/tests/issues/test_issue1061.py
+++ b/tests/issues/test_issue1061.py
@@ -9,7 +9,7 @@ from tests.functional.test_tag_inheritance import assert_inherited_tags_equal_to
 # -----------------------------------------------------------------------------
 # TEST SUITE
 # -----------------------------------------------------------------------------
-class TestIssue(object):
+class TestIssue:
     """Verifies that issue is fixed.
     Verifies basics that tag-inheritance mechanism works.
 

--- a/tests/unit/contrib/test_csv_table_from_file.py
+++ b/tests/unit/contrib/test_csv_table_from_file.py
@@ -31,7 +31,7 @@ def table_to_list_of_dicts(table):
     return [row.as_dict() for row in table.rows]
 
 
-class ExampleBuilder(object):
+class ExampleBuilder:
     DEFAULT_FILENAME = "some.feature"
     DEFAULT_KEYWORD = "Examples"
     DEFAULT_LINE = 10

--- a/tests/unit/formatter/test_base.py
+++ b/tests/unit/formatter/test_base.py
@@ -84,7 +84,7 @@ def clean_environment():
 # -----------------------------------------------------------------------------
 # TEST SUITE
 # -----------------------------------------------------------------------------
-class TestStreamOpener(object):
+class TestStreamOpener:
     EXAMPLE_TEXT = "Nur Äarger mit Jürgen"
     ENCODINGS = [
         "UTF-8", "UTF-8-sig",  # UTF-8 with BOM

--- a/tests/unit/model_builder.py
+++ b/tests/unit/model_builder.py
@@ -14,7 +14,7 @@ from behave._types import Unknown
 # -----------------------------------------------------------------------------
 # BUILDER VIEW CLASSES:
 # -----------------------------------------------------------------------------
-class BuilderView(object):
+class BuilderView:
     @staticmethod
     def select_builder_attribute(builder, name, default=None):
         if name.startswith("_"):
@@ -81,7 +81,7 @@ class BuilderContext(BuilderView):
         # return super(BuilderItemView, self).__getattribute__(name)
 
 
-class  BuilderOperationsMixin(object):
+class  BuilderOperationsMixin:
     @staticmethod
     def with_names(ctx, names, default_name=None):
         assert isinstance(ctx, BuilderContext)
@@ -252,7 +252,7 @@ class  BuilderOperationsMixin(object):
 # -----------------------------------------------------------------------------
 # BUILDER MIXIN CLASSES:
 # -----------------------------------------------------------------------------
-class FilenameBuilderMixin(object):
+class FilenameBuilderMixin:
     FILENAME_SCHEMA = "features/f_{0:03d}.feature"
     COUNTER = 0
 
@@ -298,7 +298,7 @@ class ManyFeaturesBuilderMixin(FeatureBuilderMixin):
         # return BuilderSequenceView(builder=self, data=self.features, offset=offset)
 
 
-class RuleBuilderMixin(object):
+class RuleBuilderMixin:
 
     def make_rule(self, **kwargs):
         filename = kwargs.pop("filename", None)
@@ -357,7 +357,7 @@ class ManyRulesBuilderMixin(RuleBuilderMixin):
         # return BuilderSequenceView(builder=self, data=self.current_sequence())
 
 
-class ScenarioBuilderMixin(object):
+class ScenarioBuilderMixin:
     SCENARIO_DEFAULT_PARAMS = {
         "keyword": "Scenario",
         "name": "",
@@ -434,7 +434,7 @@ class ManyScenariosBuilderMixin(ScenarioBuilderMixin):
         # return BuilderSequenceView(builder=self, data=self.current_sequence())
 
 
-class ManyStepsBuilderMixin(object):
+class ManyStepsBuilderMixin:
     DEFAULT_STEP = "a step passes"
     DEFAULT_STEP_KEYWORD = "Given"
     DEFAULT_STEP_TYPE = "given"

--- a/tests/unit/reporter/test_summary.py
+++ b/tests/unit/reporter/test_summary.py
@@ -10,7 +10,7 @@ from behave.reporter.summary import (
 import pytest
 
 
-class TestFormatStatus(object):
+class TestFormatStatus:
     def test_passed_entry_contains_label(self):
         format_summary = format_summary_v2
         summary = {
@@ -79,7 +79,7 @@ class TestFormatStatus(object):
         assert Status.undefined.name not in output
 
 
-class TestSummaryReporter(object):
+class TestSummaryReporter:
     OUTPUT_FORMATS = list(OUTPUT_FORMAT_MAP.keys())
 
     @staticmethod

--- a/tests/unit/tag_expression/test_builder.py
+++ b/tests/unit/tag_expression/test_builder.py
@@ -43,7 +43,7 @@ def assert_is_tag_expression_v2(tag_expression):
 # -----------------------------------------------------------------------------
 # TEST SUITE
 # -----------------------------------------------------------------------------
-class TestTagExpressionProtocol(object):
+class TestTagExpressionProtocol:
     """
     Test TagExpressionProtocol class.
     """
@@ -65,7 +65,7 @@ class TestTagExpressionProtocol(object):
 # -----------------------------------------------------------------------------
 # TEST SUITE FOR: make_tag_expression()
 # -----------------------------------------------------------------------------
-class TestMakeTagExpression(object):
+class TestMakeTagExpression:
     """Test :func:`make_tag_expression()`."""
 
     @pytest.mark.parametrize("text", TAG_EXPRESSION_V2_GOOD_EXAMPLES)

--- a/tests/unit/tag_expression/test_model.py
+++ b/tests/unit/tag_expression/test_model.py
@@ -9,7 +9,7 @@ import pytest
 # -----------------------------------------------------------------------------
 # TEST SUITE: Model Classes
 # -----------------------------------------------------------------------------
-class TestAndOperation(object):
+class TestAndOperation:
 
     @pytest.mark.parametrize("expected, tags, case", [
         (False, [],             "no_tags"),
@@ -49,7 +49,7 @@ class TestAndOperation(object):
         assert expected == str(expression)
 
 
-class TestOrOperation(object):
+class TestOrOperation:
     @pytest.mark.parametrize("expected, tags, case", [
         (False, [],         "no_tags"),
         ( True, ["a"],      "one tag: a"),
@@ -83,7 +83,7 @@ class TestOrOperation(object):
         assert expression.evaluate(tags) == expected
 
 
-class TestNotOperation(object):
+class TestNotOperation:
     @pytest.mark.parametrize("expected, tags, case", [
         ( True, [],         "no_tags"),
         (False, ["a"],      "one tag: a"),
@@ -97,7 +97,7 @@ class TestNotOperation(object):
         assert expression.evaluate(tags) == expected
 
 
-class TestTrueOperation(object):
+class TestTrueOperation:
     @pytest.mark.parametrize("expected, tags, case", [
         ( True, [],         "no_tags"),
         ( True, ["a"],      "one tag: a"),
@@ -108,7 +108,7 @@ class TestTrueOperation(object):
         assert expression.evaluate(tags) == expected
 
 
-class TestComposedExpression(object):
+class TestComposedExpression:
     @pytest.mark.parametrize("expected, tags, case", [
         ( True, [],         "no_tags"),
         ( True, ["a"],      "one tag: a"),

--- a/tests/unit/tag_expression/test_model_ext.py
+++ b/tests/unit/tag_expression/test_model_ext.py
@@ -7,7 +7,7 @@ import pytest
 # TEST SUITE: Model Class Extension(s)
 # -----------------------------------------------------------------------------
 # NOT-NEEDED: xfail = pytest.mark.xfail
-class TestExpression(object):
+class TestExpression:
 
     def test_check__can_be_used(self):
         tag_expression = Literal("foo")
@@ -15,7 +15,7 @@ class TestExpression(object):
         assert tag_expression.check(["other"]) is False
 
 
-class TestMatcher(object):
+class TestMatcher:
     @pytest.mark.parametrize("expected, tag, case", [
         (True, "foo.bar", "startswith_1"),
         (True, "foo.bax", "startswith_2"),
@@ -49,7 +49,7 @@ class TestMatcher(object):
         expression = Matcher("*.foo.*")
         assert expression.evaluate([tag]) == expected
 
-class TestNever(object):
+class TestNever:
     @pytest.mark.parametrize("tags, case", [
         ([], "no_tags"),
         (["foo", "bar"], "some tags"),

--- a/tests/unit/tag_expression/test_parser.py
+++ b/tests/unit/tag_expression/test_parser.py
@@ -14,7 +14,7 @@ import pytest
 # TEST SUITE: Grammar
 # -----------------------------------------------------------------------------
 # SAME-AS: cucumber/tag-expressions/python/tests/unit/test_parser:TestToken
-class TestToken(object):
+class TestToken:
 
     @pytest.mark.parametrize("token, expected", [
         (Token.OR, Associative.LEFT),
@@ -98,7 +98,7 @@ class TestToken(object):
 # -----------------------------------------------------------------------------
 # TEST SUITE: Parser
 # -----------------------------------------------------------------------------
-class TagExpressionParserTestBase(object):
+class TagExpressionParserTestBase:
     @staticmethod
     def assert_parse_expression_equals_expression_string(text, expected):
         parser = TagExpressionParser()

--- a/tests/unit/test_ansi_escapes.py
+++ b/tests/unit/test_ansi_escapes.py
@@ -54,7 +54,7 @@ def test_module_setup():
     assert escapes_count >= (2 + aliases_count + aliases_count)
 
 
-class TestStripEscapes(object):
+class TestStripEscapes:
 
     @pytest.mark.parametrize("text", TEXTS)
     def test_should_return_same_text_without_escapes(self, text):

--- a/tests/unit/test_capture.py
+++ b/tests/unit/test_capture.py
@@ -56,7 +56,7 @@ not_implemented = pytest.mark.not_implemented()
 # -----------------------------------------------------------------------------
 # TEST SUITE:
 # -----------------------------------------------------------------------------
-class TestCaptured(object):
+class TestCaptured:
 
     def test_default_ctor(self):
         captured = Captured()
@@ -319,7 +319,7 @@ Charly
         assert captured3.make_report() == expected
 
 
-class TestManyCapture(object):
+class TestManyCapture:
     def test_add_captured__with_empty_captured_data(self):
         captured = Captured()
         collector = ManyCaptured()
@@ -443,7 +443,7 @@ Fred
         assert report == expected
 
 
-class Theory4ActiveCaptureController(object):
+class Theory4ActiveCaptureController:
     @staticmethod
     def check_invariants(controller):
         if controller.config.capture_stdout:
@@ -465,7 +465,7 @@ class Theory4ActiveCaptureController(object):
         else:
             assert controller.capture_log is None
 
-class TestCaptureBookmark(object):
+class TestCaptureBookmark:
     def test_ctor__with_default_values(self):
         bookmark = CaptureBookmark()
         assert bookmark.offset_stdout == 0
@@ -546,7 +546,7 @@ class TestCaptureBookmark(object):
         assert captured_delta is NO_CAPTURED_DATA
 
 
-class TestCaptureController(object):
+class TestCaptureController:
 
     # @pytest.no_capture
     def test_basics_using_stdfd(self):
@@ -779,20 +779,20 @@ class TestCaptureController(object):
 
 @todo
 @not_implemented
-class TestCaptureSinkAsCollector(object):
+class TestCaptureSinkAsCollector:
     pass
 
 @todo
 @not_implemented
-class TestCaptureSink2Print(object):
+class TestCaptureSink2Print:
     pass
 
 @todo
 @not_implemented
-class TestCaptureOutputToSink(object):
+class TestCaptureOutputToSink:
     pass
 
 @todo
 @not_implemented
-class TestCaptureOutputDecorator(object):
+class TestCaptureOutputDecorator:
     pass

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -80,7 +80,7 @@ def use_current_directory(directory_path):
 # -----------------------------------------------------------------------------
 # TEST SUITE:
 # -----------------------------------------------------------------------------
-class TestConfiguration(object):
+class TestConfiguration:
 
     @pytest.mark.parametrize(("filename", "contents"), list(TEST_CONFIGS))
     def test_read_file(self, filename, contents, tmp_path):
@@ -229,7 +229,7 @@ class TestConfigurationUserData(TestCase):
         assert config.userdata_defines is None
 
 
-class TestConfigFileParser(object):
+class TestConfigFileParser:
 
     def test_configfile_iter__verify_option_names(self):
         config_options = configfile_options_iter(None)
@@ -280,7 +280,7 @@ class TestConfigFileParser(object):
         assert sorted(config_options_names) == expected_names
 
 
-class TestConfigFile(object):
+class TestConfigFile:
 
     @staticmethod
     def make_config_file_with_tag_expression_protocol(value, tmp_path):

--- a/tests/unit/test_context_cleanups.py
+++ b/tests/unit/test_context_cleanups.py
@@ -24,7 +24,7 @@ def cleanup_func():
 def cleanup_func_with_args(*args, **kwargs):
     pass
 
-class CleanupFunction(object):
+class CleanupFunction:
     def __init__(self, name="CLEANUP-FUNC", listener=None):
         self.name = name
         self.listener = listener
@@ -35,7 +35,7 @@ class CleanupFunction(object):
             self.listener(message)
 
 
-class CallListener(object):
+class CallListener:
     def __init__(self):
         self.collected = []
 
@@ -50,7 +50,7 @@ def make_context():
 # ------------------------------------------------------------------------------
 # TESTS:
 # ------------------------------------------------------------------------------
-class TestContextCleanup(object):
+class TestContextCleanup:
 
     def test_cleanup_func_is_called_when_context_frame_is_popped(self):
         my_cleanup = Mock(spec=cleanup_func)
@@ -168,7 +168,7 @@ class TestContextCleanup(object):
         my_cleanup.assert_called_once_with(1, 2, 3, name="alice")
 
     def test_add_cleanup__rejects_noncallable_cleanup_func(self):
-        class NonCallable(object):
+        class NonCallable:
             pass
         non_callable = NonCallable()
         context = make_context()
@@ -219,7 +219,7 @@ class TestContextCleanup(object):
         def bad_cleanup2():
             raise RuntimeError("CLEANUP_2")
 
-        class CleanupErrorCollector(object):
+        class CleanupErrorCollector:
             def __init__(self):
                 self.collected = []
             def __call__(self, context, cleanup_func, exception):
@@ -242,7 +242,7 @@ class TestContextCleanup(object):
         assert collect_cleanup_error.collected[1][:-1] == expected[1][:-1]
 
 
-class TestContextCleanupWithLayer(object):
+class TestContextCleanupWithLayer:
     """Tests :meth:`behave.runner.Context.add_cleanup()`
     with layer parameter.
 

--- a/tests/unit/test_cucumber_expression.py
+++ b/tests/unit/test_cucumber_expression.py
@@ -59,7 +59,7 @@ def parse_number(text):
 # -----------------------------------------------------------------------------
 # TEST SUPPORT
 # -----------------------------------------------------------------------------
-class FakeContext(object):
+class FakeContext:
     def __init__(self, **kwargs):
         for name, value in kwargs.items():
             setattr(self, name, value)
@@ -73,7 +73,7 @@ def step_do_nothing(ctx, *args, **kwargs):
     print("STEP CALLED WITH: args=%r, kwargs=%r" % (args, kwargs))
 
 
-class StepRunner(object):
+class StepRunner:
     def __init__(self, step_matcher):
         self.step_matcher = step_matcher
 
@@ -113,25 +113,25 @@ def parameter_type_registry():
 # TEST SUITE -- REQUIRES: Python3, probably Python.version >= 3.8
 # -----------------------------------------------------------------------------
 if HAVE_CUCUMBER_EXPRESSIONS:
-    class TestBasics(object):
+    class TestBasics:
         """Tests that checks basic functionality."""
         pass
 
 
-    class TestParameterType4Int(object):
+    class TestParameterType4Int:
         """Using predefined :class:`ParameterType`(s) for integer numbers"""
 
 
-    class TestParameterType4Float(object):
+    class TestParameterType4Float:
         """Using predefined :class:`ParameterType`(s) for float numbers"""
 
 
-    class TestParameterType4String(object):
+    class TestParameterType4String:
         """Using predefined :class:`ParameterType`(s) for string(s)"""
         pass
 
 
-    class TestParameterType4User(object):
+    class TestParameterType4User:
         """Tests using own, user-defined ParameterType(s)."""
 
         @pytest.mark.parametrize("color_name", COLOR_NAMES)
@@ -175,7 +175,7 @@ if HAVE_CUCUMBER_EXPRESSIONS:
             step_runner.assert_step_is_not_matched(step_text)
 
 
-    class TestWithTypeBuilder(object):
+    class TestWithTypeBuilder:
         """
         Use CucumberExpressions with :class:`TypeBuilder`.
         Reuses :class:`parse_type.TypeBuilder` for "parse-expressions".

--- a/tests/unit/test_deprecated.py
+++ b/tests/unit/test_deprecated.py
@@ -24,7 +24,7 @@ if PythonFeature.has_async_function():
 # -----------------------------------------------------------------------------
 # TEST SUITE -- DEPRECATED THINGS
 # -----------------------------------------------------------------------------
-class TestActiveTagMatcher(object):
+class TestActiveTagMatcher:
     def test_deprecated_should_exclude_with(self):
         active_tag_matcher = ActiveTagMatcher({})
         expected = r"Use 'should_skip_with_tags\(\)' instead"
@@ -44,7 +44,7 @@ class TestActiveTagMatcher(object):
             _ = active_tag_matcher.should_run_with([])
 
 
-class TestConfiguration(object):
+class TestConfiguration:
 
     # -- SINCE: behave v1.2.7
     def test_deprecated_use_stdout_capture__as_getter(self):
@@ -128,7 +128,7 @@ class TestConfiguration(object):
             _config = Configuration(log_capture=True, load_config=False)
 
 
-class TestCaptureController(object):
+class TestCaptureController:
     SETUP_CAPTURE_EXPECTED = "setup_capture: Avoid to use 'context' parameter"
     @staticmethod
     def make_context(config):
@@ -226,14 +226,14 @@ class TestCaptureController(object):
             capture_controller.log_capture = True
 
 
-class TestFormatterModule(object):
+class TestFormatterModule:
     def test_deprecated_on_impoort(self):
         expected = "Use 'behave.formatter._registry' instead."
         with pytest.warns(DeprecationWarning, match=expected):
             import behave.formatter.formatters  # noqa: F401
 
 
-class TestModellRunner(object):
+class TestModellRunner:
     HOOK_NAMES = [
         "before_all", "after_all",
         "before_feature", "after_feature",

--- a/tests/unit/test_explore_generator.py
+++ b/tests/unit/test_explore_generator.py
@@ -8,7 +8,7 @@ import pytest
 from contextlib import contextmanager
 
 
-class TestContextManager(object):
+class TestContextManager:
     def test_when_setup_raises_error_then_cleanup_isnot_called(self):
         @contextmanager
         def foo(checkpoints):
@@ -44,7 +44,7 @@ class TestContextManager(object):
         assert checkpoints == ["foo.setup.begin", "foo.cleanup"]
 
 
-class TestGenerator(object):
+class TestGenerator:
     def test_when_setup_raises_error_then_cleanup_isnot_called(self):
         def foo(checkpoints):
             checkpoints.append("foo.setup.begin")

--- a/tests/unit/test_fixture.py
+++ b/tests/unit/test_fixture.py
@@ -27,7 +27,7 @@ def make_runtime_context(runner=None):
     return Context(runner)
 
 
-class BasicFixture(object):
+class BasicFixture:
     """Helper class used in behave fixtures (test-support)."""
     def __init__(self, *args, **kwargs):
         setup_called = kwargs.pop("_setup_called", True)
@@ -111,7 +111,7 @@ def assert_fixture_cleanup_not_called(fixture_obj):
 # -----------------------------------------------------------------------------
 # TEST SUITE:
 # -----------------------------------------------------------------------------
-class TestFixtureDecorator(object):
+class TestFixtureDecorator:
     def test_decorator(self):
         @fixture
         def foo(context, *args, **kwargs):
@@ -176,7 +176,7 @@ class TestFixtureDecorator(object):
         assert isinstance(the_fixture, BarFixture)
 
     def test_decorator_with_non_callable_raises_type_error(self):
-        class NotCallable(object):
+        class NotCallable:
             pass
 
         with pytest.raises(TypeError) as exc_info:
@@ -187,7 +187,7 @@ class TestFixtureDecorator(object):
         assert "Invalid func:" in exception_text
         assert "NotCallable object" in exception_text
 
-class TestUseFixture(object):
+class TestUseFixture:
 
     def test_basic_lifecycle(self):
         # -- NOTE: Use explicit checks instead of assert-helper functions.
@@ -489,7 +489,7 @@ class TestUseFixture(object):
         assert isinstance(exc_info.value, FixtureCleanupError), "LAST-EXCEPTION-WINS"
 
 
-class TestUseFixtureByTag(object):
+class TestUseFixtureByTag:
     def test_data_schema1(self):
         @fixture
         def foo(context, *args, **kwargs):
@@ -558,7 +558,7 @@ class TestUseFixtureByTag(object):
         def foo(context, *args, **kwargs):
             pass
 
-        class BadFixtureData(object):
+        class BadFixtureData:
             def __init__(self, fixture_func, *args, **kwargs):
                 self.fixture_func = fixture_func
                 self.fixture_args = args
@@ -580,7 +580,7 @@ class TestUseFixtureByTag(object):
         assert "BadFixtureData object" in str(exc_info.value)
 
 
-class TestCompositeFixture(object):
+class TestCompositeFixture:
     def test_use_fixture(self):
         @fixture
         def fixture_foo(context, checkpoints, *args, **kwargs):
@@ -851,7 +851,7 @@ class TestCompositeFixture(object):
         ]
 
 
-class TestFixtureCleanup(object):
+class TestFixtureCleanup:
     """Check fixture-cleanup behaviour w/ different fixture implementations."""
 
     def test_setup_eror_with_plaingen_then_cleanup_is_not_called(self):

--- a/tests/unit/test_importer.py
+++ b/tests/unit/test_importer.py
@@ -11,7 +11,7 @@ import types
 import pytest
 
 
-class TestTheory(object):
+class TestTheory:
     """Marker for test-theory classes as syntactic sugar."""
     pass
 
@@ -43,7 +43,7 @@ class ImportModuleTheory(TestTheory):
         assert module.__name__ == name
 
 
-class TestLoadModule(object):
+class TestLoadModule:
     theory = ImportModuleTheory
 
     def test_load_module__should_fail_for_unknown_module(self):
@@ -67,7 +67,7 @@ class TestLoadModule(object):
         self.theory.assert_module_is_imported(module_name)
 
 
-class TestLazyObject(object):
+class TestLazyObject:
 
     def test_get__should_succeed_for_known_object(self):
         lazy = LazyObject("behave.importer", "LazyObject")
@@ -118,7 +118,7 @@ class LazyDictTheory(TestTheory):
         assert not isinstance(obj, LazyObject)
 
 
-class TestLazyDict(object):
+class TestLazyDict:
     theory = LazyDictTheory
 
     def test_unknown_item_access__should_raise_keyerror(self):

--- a/tests/unit/test_log_capture.py
+++ b/tests/unit/test_log_capture.py
@@ -2,9 +2,9 @@ from unittest.mock import patch
 from behave.log_capture import LoggingCapture
 
 
-class TestLogCapture(object):
+class TestLogCapture:
     def test_get_value_returns_all_log_records(self):
-        class FakeConfig(object):
+        class FakeConfig:
             logging_filter = None
             logging_format = None
             logging_datefmt = None

--- a/tests/unit/test_matchers.py
+++ b/tests/unit/test_matchers.py
@@ -16,7 +16,7 @@ class DummyMatcher(Matcher):
     def check_match(self, step):
         return DummyMatcher.desired_result
 
-class TestMatcher(object):
+class TestMatcher:
     # pylint: disable=invalid-name, no-self-use
 
     def setUp(self):
@@ -38,7 +38,7 @@ class TestMatcher(object):
         assert match.func is func
         assert match.arguments == arguments
 
-class TestParseMatcher(object):
+class TestParseMatcher:
     # pylint: disable=invalid-name, no-self-use
     STEP_MATCHER_CLASS = ParseMatcher
 
@@ -250,7 +250,7 @@ class TestCFParseMatcher(TestParseMatcher):
         assert self.recorded_args, ((context,) == expected)
 
 
-class TestRegexMatcher(object):
+class TestRegexMatcher:
     # pylint: disable=invalid-name, no-self-use
     STEP_MATCHER_CLASS = RegexMatcher
 

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -289,7 +289,7 @@ class TestScenarioRun(unittest.TestCase):
         assert scenario.should_run_with_name_select(self.config)
 
 
-class TestScenarioRun2(object):
+class TestScenarioRun2:
     """Some additional tests for "Scenario.run()" using pytest."""
     @classmethod
     def make_runner(cls):
@@ -869,7 +869,7 @@ class TestStepRun(unittest.TestCase):
         assert "toads" in captured_output
 
 
-class TestTableModel(object):
+class TestTableModel:
     # pylint: disable=invalid-name
     HEADINGS = ["type of stuff", "awesomeness", "ridiculousness"]
     TABLE_DATA = [
@@ -921,7 +921,7 @@ class TestTableModel(object):
         assert list(table[0].items()) == list(zip(self.HEADINGS, self.TABLE_DATA[0]))
 
 
-class TestModelRow(object):
+class TestModelRow:
     # pylint: disable=invalid-name, bad-whitespace
     HEADINGS = ["name",  "sex",   "age"]
     ROW_DATA = ["Alice", "female", "12"]

--- a/tests/unit/test_model2.py
+++ b/tests/unit/test_model2.py
@@ -35,7 +35,7 @@ def step_to_text(step, indentation="    "):
 # ----------------------------------------------------------------------------
 # TEST SUITE:
 # ----------------------------------------------------------------------------
-class TestScenarioOutlineBuilder(object):
+class TestScenarioOutlineBuilder:
     """Unit tests for the templating mechanism that is provided by the
     :class:`behave.model:ScenarioOutlineBuilder`.
     """
@@ -386,7 +386,7 @@ Feature:
         assert scenario1_tags == expected_tags[1]
 
 
-class TestTag(object):
+class TestTag:
     """
     Translation rules are:
       * alnum chars => same, kept

--- a/tests/unit/test_model_core.py
+++ b/tests/unit/test_model_core.py
@@ -9,7 +9,7 @@ from behave.model_type import Status, FileLocation
 # -----------------------------------------------------------------------------
 # TESTS:
 # -----------------------------------------------------------------------------
-class TestStatus(object):
+class TestStatus:
     """Test Status enum class.
     In addition, checks if it is partly backward compatibility to
     string-based status.
@@ -54,7 +54,7 @@ class TestStatus(object):
             Status.from_name(unknown_name)
 
 
-class TestFileLocation(object):
+class TestFileLocation:
     # pylint: disable=invalid-name
     ordered_locations1 = [
         FileLocation("features/alice.feature", 1),

--- a/tests/unit/test_model_type.py
+++ b/tests/unit/test_model_type.py
@@ -13,17 +13,17 @@ todo = pytest.mark.todo()
 # TEST SUITE
 # -----------------------------------------------------------------------------
 @todo
-class TestStatus(object):
+class TestStatus:
     pass
 
 @todo
-class TestScenarioStatus(object):
+class TestScenarioStatus:
     pass
 
 @todo
-class TestOuterStatus(object):
+class TestOuterStatus:
     pass
 
 @todo
-class TestFileLocation(object):
+class TestFileLocation:
     pass

--- a/tests/unit/test_parameter_type.py
+++ b/tests/unit/test_parameter_type.py
@@ -32,7 +32,7 @@ def os_environ():
 # -----------------------------------------------------------------------------
 # TEST SUITE
 # -----------------------------------------------------------------------------
-class TestParseNumber(object):
+class TestParseNumber:
     TYPE_REGISTRY = dict(Number=parse_number)
     PATTERN = "Number: {number:Number}"
     TEXT_TEMPLATE = "Number: {}"
@@ -64,7 +64,7 @@ class TestParseNumber(object):
         self.assert_mismatch_with_parse_number(text)
 
 
-class TestParseAnyText(object):
+class TestParseAnyText:
     TYPE_REGISTRY = dict(AnyText=parse_any_text)
     PATTERN = 'AnyText: "{some:AnyText}"'
     TEXT_TEMPLATE = 'AnyText: "{}"'
@@ -104,7 +104,7 @@ class TestParseAnyText(object):
         self.assert_match_with_parse_any_and_converts_to_string(text, expected)
 
 
-class TestParseUnquotedText(object):
+class TestParseUnquotedText:
     TYPE_REGISTRY = dict(Unquoted=parse_unquoted_text)
     PATTERN = 'Unquoted: "{some:Unquoted}"'
     TEXT_TEMPLATE = 'Unquoted: "{}"'
@@ -148,7 +148,7 @@ class TestParseUnquotedText(object):
         self.assert_mismatch_with_parse_unquoted(text)
 
 
-class TestParseEnvironmentVar(object):
+class TestParseEnvironmentVar:
     TYPE_REGISTRY = dict(EnvironmentVar=parse_environment_var)
     PATTERN = 'EnvironmentVar: "{param:EnvironmentVar}"'
     TEXT_TEMPLATE = 'EnvironmentVar: "{}"'

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -27,7 +27,7 @@ def assert_compare_steps(steps, expected):
 # ---------------------------------------------------------------------------
 # TEST SUITE
 # ---------------------------------------------------------------------------
-class TestParser(object):
+class TestParser:
     # pylint: disable=too-many-public-methods, no-self-use
 
     def test_parses_feature_name(self):
@@ -984,7 +984,7 @@ Feature: Stuff
             parse_feature(text)
 
 
-class TestParser4AndButSteps(object):
+class TestParser4AndButSteps:
     def test_parse_scenario_with_and_and_but(self):
         doc = """
 Feature: Stuff
@@ -1117,7 +1117,7 @@ Feature: Scenario first step uses And/But
         ])
 
 
-class TestForeign(object):
+class TestForeign:
     # pylint: disable=no-self-use
 
     def test_first_line_comment_sets_language(self):
@@ -1362,7 +1362,7 @@ Fonctionnalité: testing stuff
         ])
 
 
-class TestParser4ScenarioDescription(object):
+class TestParser4ScenarioDescription:
     # pylint: disable=no-self-use
 
     def test_parse_scenario_description(self):
@@ -1511,7 +1511,7 @@ Feature: Scenario Description
         ])
 
 
-class TestParser4Tags(object):
+class TestParser4Tags:
     # pylint: disable=no-self-use
 
     def test_parse_tags_with_one_tag(self):
@@ -1545,7 +1545,7 @@ class TestParser4Tags(object):
             parse_tags('@one  invalid.tag boom')
 
 
-class TestParser4Background(object):
+class TestParser4Background:
     # pylint: disable=no-self-use
 
     def test_parse_background(self):
@@ -1689,7 +1689,7 @@ Feature: Background after ScenarioOutline
             parse_feature(text)
 
 
-class TestParser4Steps(object):
+class TestParser4Steps:
     """
     Tests parse_steps() and Parser.parse_steps() functionality.
     """

--- a/tests/unit/test_parser_gherkin_v6.py
+++ b/tests/unit/test_parser_gherkin_v6.py
@@ -55,11 +55,11 @@ def assert_compare_steps(steps, expected):
 # TEST SUITE
 # ---------------------------------------------------------------------------
 
-class TestGherkin6Parser(object):
+class TestGherkin6Parser:
     pass
 
 
-class TestParser4Rule(object):
+class TestParser4Rule:
 
     @pytest.mark.smoke
     def test_parses_rule(self):
@@ -655,7 +655,7 @@ Feature: With Scenarios and Rules
 # ---------------------------------------------------------------------------
 # TEST SUITE: Verify Feature Background to Rule Background Inheritance
 # ---------------------------------------------------------------------------
-class TestParser4Background(object):
+class TestParser4Background:
     """Verify feature.background to rule.background inheritance, etc."""
 
     def test_parse__norule_scenarios_use_feature_background(self):
@@ -956,7 +956,7 @@ class TestParser4Background(object):
 # ---------------------------------------------------------------------------
 # TEST SUITE: Verify Alias keywords
 # ---------------------------------------------------------------------------
-class TestParser4Scenario(object):
+class TestParser4Scenario:
     def test_use_example_alias(self):
         """HINT: Some Scenarios may exist before the first Rule."""
         text = '''
@@ -987,7 +987,7 @@ Feature: With Example as Alias for Scenario
         ])
 
 
-class TestParser4ScenarioOutline(object):
+class TestParser4ScenarioOutline:
     def test_use_scenario_template_alias(self):
         """HINT: Some Scenarios may exist before the first Rule."""
         text = '''

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -19,7 +19,7 @@ def create_mock_config():
     return config
 
 
-class TestRunner(object):
+class TestRunner:
     # pylint: disable=invalid-name, no-self-use
 
     def test_load_hooks_execfiles_hook_file(self):
@@ -279,7 +279,7 @@ class TestRunWithPaths(unittest.TestCase):
         assert self.runner.features == [feature] * 3
 
 
-class FsMock(object):
+class FsMock:
     def __init__(self, *paths):
         self.base = os.path.abspath(".")
         self.sep = os.path.sep
@@ -367,7 +367,7 @@ class FsMock(object):
         return orig(path)
 
 
-class TestFeatureDirectory(object):
+class TestFeatureDirectory:
     # pylint: disable=invalid-name, no-self-use
 
     def test_default_path_no_steps(self):
@@ -500,7 +500,7 @@ class TestFeatureDirectory(object):
                 # OLD: assert_raises(ConfigError, runner.setup_paths)
 
 
-class TestFeatureDirectoryLayout2(object):
+class TestFeatureDirectoryLayout2:
     # pylint: disable=invalid-name, no-self-use
 
     def test_default_path(self):

--- a/tests/unit/test_runner_context.py
+++ b/tests/unit/test_runner_context.py
@@ -19,7 +19,7 @@ from behave.runner import (
 from behave.step_registry import StepRegistry
 
 
-class TestContext(object):
+class TestContext:
     @staticmethod
     def make_runner(config=None):
         if config is None:
@@ -348,7 +348,7 @@ class TestContext2(unittest.TestCase):
             del self.context.thing
 
 
-class ExampleSteps(object):
+class ExampleSteps:
     text = None
     table = None
 

--- a/tests/unit/test_runner_hook.py
+++ b/tests/unit/test_runner_hook.py
@@ -61,7 +61,7 @@ def any_tag_hook(ctx, tag):
 # -----------------------------------------------------------------------------
 # TEST SUITE
 # -----------------------------------------------------------------------------
-class TestRunHooks(object):
+class TestRunHooks:
 
     @staticmethod
     def make_runner(**config_data):

--- a/tests/unit/test_runner_plugin.py
+++ b/tests/unit/test_runner_plugin.py
@@ -89,7 +89,7 @@ class PhoenixTestRunner(ITestRunner):
         return self.the_runner.undefined_steps
 
 
-class RegisteredTestRunner(object):
+class RegisteredTestRunner:
     """Not derived from :class:`behave.api.runner:ITestrunner`.
     In this case, you need to register this class to the interface class.
     """
@@ -117,7 +117,7 @@ ITestRunner.register(RegisteredTestRunner)
 INVALID_TEST_RUNNER_CLASS0 = True
 
 
-class InvalidTestRunnerNotSubclass(object):
+class InvalidTestRunnerNotSubclass:
     """SYNDROME: Missing ITestRunner.register(InvalidTestRunnerNotSubclass)."""
     def __int__(self, config):
         self.undefined_steps = []
@@ -160,7 +160,7 @@ class InvalidTestRunnerWithoutUndefinedSteps(ITestRunner):
 # -----------------------------------------------------------------------------
 # TEST SUITE:
 # -----------------------------------------------------------------------------
-class TestRunnerPlugin(object):
+class TestRunnerPlugin:
     """Test the runner-plugin configuration."""
     THIS_MODULE_NAME = CustomTestRunner.__module__
 

--- a/tests/unit/test_runner_util.py
+++ b/tests/unit/test_runner_util.py
@@ -62,7 +62,7 @@ feature_file_map = {
 # ---------------------------------------------------------------------------------------
 # TEST SUITE FOR: FeatureLineDatabase
 # ---------------------------------------------------------------------------------------
-class TestFeatureLineDatabase(object):
+class TestFeatureLineDatabase:
     def test_make(self):
         feature = parse_feature(feature_text1.strip(),
                                 filename="features/Alice.feature")

--- a/tests/unit/test_step_registry.py
+++ b/tests/unit/test_step_registry.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 from behave import step_registry
 
 
-class TestStepRegistry(object):
+class TestStepRegistry:
     # pylint: disable=invalid-name, no-self-use
 
     def test_add_step_definition_adds_to_lowercased_keyword(self):

--- a/tests/unit/test_summary.py
+++ b/tests/unit/test_summary.py
@@ -43,7 +43,7 @@ import pytest
 #                 .each_with_steps(passed=3)
 
 
-# class ScenarioStatus(object):
+# class ScenarioStatus:
 #     """Computes ``scenario.status`` from ``step.status``."""
 #     @staticmethod
 #     def from_step_status(status, dry_run=False):
@@ -66,7 +66,7 @@ def assert_counts_are_zero(counts, excluded=None):
 # -----------------------------------------------------------------------------
 # TEST SUITE
 # -----------------------------------------------------------------------------
-class TestStatusCounts(object):
+class TestStatusCounts:
     def test_ctor_all_counts_are_zero(self):
         status_counts = StatusCounts()
         assert_counts_are_zero(status_counts)
@@ -126,7 +126,7 @@ class TestStatusCounts(object):
         assert the_counts.all == expected
 
 
-class TestSummaryCollector(object):
+class TestSummaryCollector:
 
     def test_process_feature_with_one_passed_scenario(self):
         builder = FeatureBuilder()

--- a/tests/unit/test_tag_matcher.py
+++ b/tests/unit/test_tag_matcher.py
@@ -21,7 +21,7 @@ from behave.tag_matcher import (
 )
 
 
-class Traits4ActiveTagMatcher(object):
+class Traits4ActiveTagMatcher:
     TagMatcher = ActiveTagMatcher
     value_provider = {
         "foo": "alice",
@@ -59,7 +59,7 @@ class Traits4ActiveTagMatcher(object):
 
 
 # -- REQUIRES: pytest
-class TestActiveTagMatcher2(object):
+class TestActiveTagMatcher2:
     TagMatcher = ActiveTagMatcher
     traits = Traits4ActiveTagMatcher
 
@@ -446,7 +446,7 @@ class NumberValueObject(ValueObject):
 # -----------------------------------------------------------------------------
 # TEST SUITE WITH: ActiveTag ValueObject(s)
 # -----------------------------------------------------------------------------
-class TestActiveTagMatcherWithValueObject(object):
+class TestActiveTagMatcherWithValueObject:
     """Tests :class:`behave.tag_matcher.ValueObject` functionality.
 
     ValueObject(s) support additional comparison functions that matches

--- a/tests/unit/test_textutil.py
+++ b/tests/unit/test_textutil.py
@@ -11,7 +11,7 @@ from behave.textutil import text
 # -----------------------------------------------------------------------------
 # TEST SUPPORT:
 # -----------------------------------------------------------------------------
-class ConvertableToUnicode(object):
+class ConvertableToUnicode:
     """Class that can be converted into a unicode string.
     If parameter is a bytes-string, it is converted into unicode.
 
@@ -42,7 +42,7 @@ class ConvertableToUnicode(object):
         return text
 
 
-class ConvertableToString(object):
+class ConvertableToString:
     encoding = "utf-8"
 
     def __init__(self, text, encoding=None):
@@ -56,7 +56,7 @@ class ConvertableToString(object):
         return text
 
 
-class ConvertableToPy2String(object):
+class ConvertableToPy2String:
     encoding = "utf-8"
 
     def __init__(self, text, encoding=None):
@@ -92,7 +92,7 @@ BYTES_TEXT_TUPLES_WITH_UTF8_ENCODING = [
 ]
 
 
-class TestTextConversion(object):
+class TestTextConversion:
     """Unit tests for the :func:`behave.textutil.text()` function."""
 
     @pytest.mark.parametrize("value", UNICODE_TEXT_VALUES)
@@ -149,7 +149,7 @@ class TestTextConversion(object):
         assert isinstance(actual_text, str)
 
 
-class TestObjectToTextConversion(object):
+class TestObjectToTextConversion:
     """Unit tests for the :func:`behave.textutil.text()` function.
     Explore case with object-to-text conversion.
     """

--- a/tests/unit/test_userdata.py
+++ b/tests/unit/test_userdata.py
@@ -7,7 +7,7 @@ import pytest
 FLOAT_ACCURACY = 0.000091
 
 
-class TestParseUserDefine(object):
+class TestParseUserDefine:
     """Test parse_user_define() function."""
 
     def test_parse__name_value(self):
@@ -48,7 +48,7 @@ class TestParseUserDefine(object):
 
 
 
-class TestUserData(object):
+class TestUserData:
     """Test UserData class."""
 
     def test_userdata_is_dictlike(self):
@@ -193,7 +193,7 @@ class TestUserData(object):
         assert value == 1.2
 
 
-class TestUserDataNamespace(object):
+class TestUserDataNamespace:
 
     def test_make_scoped(self):
         scoped_name = UserDataNamespace.make_scoped("my.scope", "param")


### PR DESCRIPTION
In Python3 all classes are "New-Style Classes"

https://www.geeksforgeeks.org/python/comparing-old-style-and-new-style-classes-in-python/

This change was edited with this script:

```
grep '(object):$' -rl | grep -v issue.feat | while read f; do sed -i 's/(object):$/:/' $f ; done
grep '(object): pass' -rl | grep -v issue.feat | while read f; do sed -i 's/(object): pass/: pass/' $f ; done
```