### PR TITLE
chore: remove assertpy dependency for build & test

### DIFF
--- a/examples/cucumber-expressions/features/steps/many_color_steps.py
+++ b/examples/cucumber-expressions/features/steps/many_color_steps.py
@@ -5,7 +5,6 @@ from behave.cucumber_expression import (
     define_parameter_type_with
 )
 from example4me.color import Color
-from assertpy import assert_that
 
 parse_color = TypeBuilder.make_enum(Color)
 parse_colors = TypeBuilder.with_many(parse_color)
@@ -29,4 +28,4 @@ def step_when_select_many_colors(ctx, colors: List[Color]):
 @then('I have selected {int} colo(u)r(s)')
 def step_then_count_selected_colors(ctx, number_of_colors: int):
     assert isinstance(number_of_colors, int)
-    assert_that(ctx.selected_colors).is_length(number_of_colors)
+    assert len(ctx.selected_colors) == number_of_colors

--- a/examples/nested_steps/features/steps/bob_steps.py
+++ b/examples/nested_steps/features/steps/bob_steps.py
@@ -13,4 +13,4 @@ def step_impl(ctx, person_name: str):
 
 @then('a dinner reservation for "{person_name:w}" and me was made')
 def step_impl(ctx, person_name: str):
-    assert ctx.dinner_reservation is ctx.person_name
+    assert ctx.dinner_reservation.name == person_name

--- a/examples/nested_steps/features/steps/bob_steps.py
+++ b/examples/nested_steps/features/steps/bob_steps.py
@@ -1,5 +1,4 @@
 from behave import given, when, then
-from assertpy import assert_that
 
 
 class DinnerReservation:
@@ -14,4 +13,4 @@ def step_impl(ctx, person_name: str):
 
 @then('a dinner reservation for "{person_name:w}" and me was made')
 def step_impl(ctx, person_name: str):
-    assert_that(ctx.dinner_reservation.name).is_equal_to(ctx.person_name)
+    assert ctx.dinner_reservation is ctx.person_name

--- a/examples/soft_asserts/features/steps/number_steps.py
+++ b/examples/soft_asserts/features/steps/number_steps.py
@@ -9,7 +9,7 @@ STEPS:
 """
 
 from behave import given, then
-from assertpy import soft_assertions
+from assertpy import assert_that, soft_assertions
 
 
 # -----------------------------------------------------------------------------
@@ -30,18 +30,12 @@ def step_then_number_is_valid(ctx, number):
 @then('the numbers "{number1:d}" and "{number2:d}" are in the valid range')
 @soft_assertions()
 def step_then_numbers_are_valid(ctx, number1, number2):
-    assert (
-        number1 >= ctx.min_number_value
-    ), f"Expected <{number1}> to be greater than or equal to {ctx.min_number_value}"
-    assert (
-        number2 >= ctx.min_number_value
-    ), f"Expected <{number2}> to be greater than or equal to {ctx.min_number_value}"
+    assert_that(number1).is_greater_than_or_equal_to(ctx.min_number_value)
+    assert_that(number2).is_greater_than_or_equal_to(ctx.min_number_value)
 
 
 @then('the positive number "{number:d}" is in the valid range')
 def step_then_positive_number_is_valid(ctx, number):
     with soft_assertions():
-        assert number >= 0, f"Expected <{number}> to be greater than or equal to 0"
-        assert (
-            number >= ctx.min_number_value
-        ), f"Expected <{number}> to be greater than or equal to {ctx.min_number_value}"
+        assert_that(number).is_greater_than_or_equal_to(0)
+        assert_that(number).is_greater_than_or_equal_to(ctx.min_number_value)

--- a/examples/soft_asserts/features/steps/number_steps.py
+++ b/examples/soft_asserts/features/steps/number_steps.py
@@ -9,7 +9,7 @@ STEPS:
 """
 
 from behave import given, then
-from assertpy import assert_that, soft_assertions
+from assertpy import soft_assertions
 
 
 # -----------------------------------------------------------------------------
@@ -22,18 +22,26 @@ def step_given_min_number_value(ctx, min_value):
 
 @then('the number "{number:d}" is in the valid range')
 def step_then_number_is_valid(ctx, number):
-    assert_that(number).is_greater_than_or_equal_to(ctx.min_number_value)
+    assert (
+        number >= ctx.min_number_value
+    ), f"Expected <{number}> to be greater than or equal to {ctx.min_number_value}"
+
 
 @then('the numbers "{number1:d}" and "{number2:d}" are in the valid range')
 @soft_assertions()
 def step_then_numbers_are_valid(ctx, number1, number2):
-    assert_that(number1).is_greater_than_or_equal_to(ctx.min_number_value)
-    assert_that(number2).is_greater_than_or_equal_to(ctx.min_number_value)
+    assert (
+        number1 >= ctx.min_number_value
+    ), f"Expected <{number1}> to be greater than or equal to {ctx.min_number_value}"
+    assert (
+        number2 >= ctx.min_number_value
+    ), f"Expected <{number2}> to be greater than or equal to {ctx.min_number_value}"
 
 
 @then('the positive number "{number:d}" is in the valid range')
 def step_then_positive_number_is_valid(ctx, number):
-    # -- ALTERNATIVE: Use ContextManager instead of disabled decorator above.
     with soft_assertions():
-        assert_that(number).is_greater_than_or_equal_to(0)
-        assert_that(number).is_greater_than_or_equal_to(ctx.min_number_value)
+        assert number >= 0, f"Expected <{number}> to be greater than or equal to 0"
+        assert (
+            number >= ctx.min_number_value
+        ), f"Expected <{number}> to be greater than or equal to {ctx.min_number_value}"

--- a/features/formatter.steps_code.feature
+++ b/features/formatter.steps_code.feature
@@ -40,7 +40,6 @@ Feature: StepWithCode Formatter
           from behave import given, when, then, step, register_type
           from behave.parameter_type import parse_number
           from example4me.calculator import Calculator
-          from assertpy import assert_that
 
           register_type(Number=parse_number)
 
@@ -54,7 +53,7 @@ Feature: StepWithCode Formatter
 
           @then('the calculator shows "{expected:Number}" as result')
           def step_when_add_number(ctx, expected):
-              assert_that(ctx.calculator.result).is_equal_to(expected)
+              assert ctx.calculator.result == expected
           """
       And a file named "features/steps/use_calculator_steps.py" with:
           """
@@ -77,28 +76,28 @@ Feature: StepWithCode Formatter
         Feature: Calculator
           Scenario: C1
             Given I use the calculator
-              # -- CODE: example4me/calculator_steps.py:8
+              # -- CODE: example4me/calculator_steps.py:7
               @given('I use the calculator')
               def step_given_reset_calculator(ctx):
                   ctx.calculator = Calculator()
 
             When I add the number "1"
-              # -- CODE: example4me/calculator_steps.py:12
+              # -- CODE: example4me/calculator_steps.py:11
               @when('I add the number "{number:Number}"')
               def step_when_add_number(ctx, number):
                   ctx.calculator.add(number)
 
             And I add the number "2"
-              # -- CODE: example4me/calculator_steps.py:12
+              # -- CODE: example4me/calculator_steps.py:11
               @when('I add the number "{number:Number}"')
               def step_when_add_number(ctx, number):
                   ctx.calculator.add(number)
 
             Then the calculator shows "3" as result
-              # -- CODE: example4me/calculator_steps.py:16
+              # -- CODE: example4me/calculator_steps.py:15
               @then('the calculator shows "{expected:Number}" as result')
               def step_when_add_number(ctx, expected):
-                  assert_that(ctx.calculator.result).is_equal_to(expected)
+                  assert ctx.calculator.result == expected
         """
       But note that "each steps contains a CODE section that shows the step implementation."
 
@@ -109,28 +108,28 @@ Feature: StepWithCode Formatter
         Feature: Calculator
           Scenario: C1
             Given I use the calculator  ...  passed
-              # -- CODE: example4me/calculator_steps.py:8
+              # -- CODE: example4me/calculator_steps.py:7
               @given('I use the calculator')
               def step_given_reset_calculator(ctx):
                   ctx.calculator = Calculator()
 
             When I add the number "1"  ...  passed
-              # -- CODE: example4me/calculator_steps.py:12
+              # -- CODE: example4me/calculator_steps.py:11
               @when('I add the number "{number:Number}"')
               def step_when_add_number(ctx, number):
                   ctx.calculator.add(number)
 
             And I add the number "2"  ...  passed
-              # -- CODE: example4me/calculator_steps.py:12
+              # -- CODE: example4me/calculator_steps.py:11
               @when('I add the number "{number:Number}"')
               def step_when_add_number(ctx, number):
                   ctx.calculator.add(number)
 
             Then the calculator shows "3" as result  ...  passed
-              # -- CODE: example4me/calculator_steps.py:16
+              # -- CODE: example4me/calculator_steps.py:15
               @then('the calculator shows "{expected:Number}" as result')
               def step_when_add_number(ctx, expected):
-                  assert_that(ctx.calculator.result).is_equal_to(expected)
+                  assert ctx.calculator.result == expected
         """
       But note that "each steps contains a CODE section that shows the step implementation"
       And note that "the step results are shown for each step (after execution)"
@@ -139,7 +138,6 @@ Feature: StepWithCode Formatter
       Given a file named "features/steps/table_steps.py" with:
         """
         from behave import given
-        from assertpy import assert_that
 
         class Person:
             def __init__(self, name, role=None):
@@ -149,7 +147,7 @@ Feature: StepWithCode Formatter
         @given('a company with the following persons')
         @given('a company with the following persons:')
         def step_given_company_with_persons(ctx):
-            assert_that(ctx.table).is_not_none()
+            assert ctx.table
             company_persons = []
             for row in ctx.table.rows:
                 name = row["Name"]
@@ -176,11 +174,11 @@ Feature: StepWithCode Formatter
               | Name  | Role      |
               | Alice | CEO       |
               | Bob   | Developer |
-              # -- CODE: features/steps/table_steps.py:9
+              # -- CODE: features/steps/table_steps.py:8
               @given('a company with the following persons')
               @given('a company with the following persons:')
               def step_given_company_with_persons(ctx):
-                  assert_that(ctx.table).is_not_none()
+                  assert ctx.table
                   company_persons = []
                   for row in ctx.table.rows:
                       name = row["Name"]
@@ -257,22 +255,22 @@ Feature: StepWithCode Formatter
           Rule: Some
             Scenario: R1
               Given I use the calculator  ...  passed
-                # -- CODE: example4me/calculator_steps.py:8
+                # -- CODE: example4me/calculator_steps.py:7
                 @given('I use the calculator')
                 def step_given_reset_calculator(ctx):
                     ctx.calculator = Calculator()
 
               When I add the number "42"  ...  passed
-                # -- CODE: example4me/calculator_steps.py:12
+                # -- CODE: example4me/calculator_steps.py:11
                 @when('I add the number "{number:Number}"')
                 def step_when_add_number(ctx, number):
                     ctx.calculator.add(number)
 
               Then the calculator shows "42" as result  ...  passed
-                # -- CODE: example4me/calculator_steps.py:16
+                # -- CODE: example4me/calculator_steps.py:15
                 @then('the calculator shows "{expected:Number}" as result')
                 def step_when_add_number(ctx, expected):
-                    assert_that(ctx.calculator.result).is_equal_to(expected)
+                    assert ctx.calculator.result == expected
         """
       But note that "each step is indented correctly"
       And note that "each step code-section is indented correctly"
@@ -284,7 +282,6 @@ Feature: StepWithCode Formatter
       Given a file named "features/steps/documented_steps.py" with:
         '''
         from behave import given, when, then
-        from assertpy import assert_that
 
         @given('a person named "{name}"')
         def step_given_person_named(ctx, name):
@@ -298,7 +295,7 @@ Feature: StepWithCode Formatter
         def step_then_met_person(ctx, expected):
             """__DOCSTRING_HERE: is not shown"""
             # -- CODE: STARTS HERE.
-            assert_that(ctx.person_name).is_equal_to(expected)
+            assert ctx.person_name == expected
         '''
       Given a file named "features/with_rule.feature" with:
         """
@@ -313,17 +310,17 @@ Feature: StepWithCode Formatter
         Feature: Using steps with docstring (not shown)
           Scenario: D1
             Given a person named "Alice"  ...  passed
-              # -- CODE: features/steps/documented_steps.py:4
+              # -- CODE: features/steps/documented_steps.py:3
               @given('a person named "{name}"')
               def step_given_person_named(ctx, name):
                   # -- CODE: STARTS HERE.
                   ctx.person_name = name
             Then I have met "Alice"  ...  passed
-              # -- CODE: features/steps/documented_steps.py:12
+              # -- CODE: features/steps/documented_steps.py:11
               @then('I have met "{expected}"')
               def step_then_met_person(ctx, expected):
                   # -- CODE: STARTS HERE.
-                  assert_that(ctx.person_name).is_equal_to(expected)
+                  assert ctx.person_name == expected
         """
       But note that "the step-function docstring is not shown in the code-section"
 
@@ -351,11 +348,10 @@ Feature: StepWithCode Formatter
       Given a file named "features/steps/failing_steps.py" with:
           """
           from behave import step
-          from assertpy import assert_that
 
           @step('{word:w} step fails')
           def step_fails(ctx, word):
-              assert_that(word).is_equal_to("__ALWAYS_FAILS__")
+              assert word == "__ALWAYS_FAILS__"
           """
       Given a file named "features/failing.feature" with:
           """
@@ -383,10 +379,10 @@ Feature: StepWithCode Formatter
                   pass
 
             When another step fails  ...  failed
-              # -- CODE: features/steps/failing_steps.py:4
+              # -- CODE: features/steps/failing_steps.py:3
               @step('{word:w} step fails')
               def step_fails(ctx, word):
-                  assert_that(word).is_equal_to("__ALWAYS_FAILS__")
+                  assert word == "__ALWAYS_FAILS__"
 
           Failing scenarios:
             features/failing.feature:3  F1 with failing step

--- a/features/runner.use_nested_step_modules.feature
+++ b/features/runner.use_nested_step_modules.feature
@@ -46,7 +46,6 @@ Feature: Use nested step modules in the steps directory
     And a file named "features/steps/nested/bob_steps.py" with:
         """
         from behave import given, when, then
-        from assertpy import assert_that
 
         class DinnerReservation:
             def __init__(self, person_name: str):
@@ -59,7 +58,7 @@ Feature: Use nested step modules in the steps directory
 
         @then('a dinner reservation for "{person_name:w}" and me was made')
         def step_impl(ctx, person_name: str):
-            assert_that(ctx.dinner_reservation.name).is_equal_to(ctx.person_name)
+            assert ctx.dinner_reservation.name == ctx.person_name
         """
     And a file named "features/f1.feature" with:
         """
@@ -94,8 +93,8 @@ Feature: Use nested step modules in the steps directory
           """
           Scenario: S1                                            # features/f1.feature:2
             Given I meet "Alice"                                  # features/steps/alice_steps.py:3
-            When I invite "Alice" for dinner                      # features/steps/nested/bob_steps.py:8
-            Then a dinner reservation for "Alice" and me was made # features/steps/nested/bob_steps.py:13
+            When I invite "Alice" for dinner                      # features/steps/nested/bob_steps.py:7
+            Then a dinner reservation for "Alice" and me was made # features/steps/nested/bob_steps.py:12
           """
         But the command output should not contain "Traceback"
 
@@ -132,12 +131,12 @@ Feature: Use nested step modules in the steps directory
             Given {word:w} step fails                           # features/steps/subdir_2/nested_steps.py:3
 
           WHEN STEP DEFINITIONS[3]:
-            When I invite "{person_name:w}" for dinner  # features/steps/nested/bob_steps.py:8
+            When I invite "{person_name:w}" for dinner  # features/steps/nested/bob_steps.py:7
             When {word:w} step passes                   # features/steps/subdir_1/nested_steps.py:3
             When {word:w} step fails                    # features/steps/subdir_2/nested_steps.py:3
 
           THEN STEP DEFINITIONS[3]:
-            Then a dinner reservation for "{person_name:w}" and me was made  # features/steps/nested/bob_steps.py:13
+            Then a dinner reservation for "{person_name:w}" and me was made  # features/steps/nested/bob_steps.py:12
             Then {word:w} step passes                                        # features/steps/subdir_1/nested_steps.py:3
             Then {word:w} step fails                                         # features/steps/subdir_2/nested_steps.py:3
 
@@ -182,12 +181,12 @@ Feature: Use nested step modules in the steps directory
             Given {word:w} step fails                           # features/steps/subdir_3/subdir_31/nested_steps.py:3
 
           WHEN STEP DEFINITIONS[3]:
-            When I invite "{person_name:w}" for dinner  # features/steps/nested/bob_steps.py:8
+            When I invite "{person_name:w}" for dinner  # features/steps/nested/bob_steps.py:7
             When {word:w} step passes                   # features/steps/subdir_1/nested_steps.py:3
             When {word:w} step fails                    # features/steps/subdir_3/subdir_31/nested_steps.py:3
 
           THEN STEP DEFINITIONS[3]:
-            Then a dinner reservation for "{person_name:w}" and me was made  # features/steps/nested/bob_steps.py:13
+            Then a dinner reservation for "{person_name:w}" and me was made  # features/steps/nested/bob_steps.py:12
             Then {word:w} step passes                                        # features/steps/subdir_1/nested_steps.py:3
             Then {word:w} step fails                                         # features/steps/subdir_3/subdir_31/nested_steps.py:3
 
@@ -234,12 +233,12 @@ Feature: Use nested step modules in the steps directory
             Given {word:w} step fails                           # features/steps/subdir_4/subdir_41/nested_steps.py:3
 
           WHEN STEP DEFINITIONS[3]:
-            When I invite "{person_name:w}" for dinner  # features/steps/nested/bob_steps.py:8
+            When I invite "{person_name:w}" for dinner  # features/steps/nested/bob_steps.py:7
             When {word:w} step passes                   # features/steps/subdir_1/nested_steps.py:3
             When {word:w} step fails                    # features/steps/subdir_4/subdir_41/nested_steps.py:3
 
           THEN STEP DEFINITIONS[3]:
-            Then a dinner reservation for "{person_name:w}" and me was made  # features/steps/nested/bob_steps.py:13
+            Then a dinner reservation for "{person_name:w}" and me was made  # features/steps/nested/bob_steps.py:12
             Then {word:w} step passes                                        # features/steps/subdir_1/nested_steps.py:3
             Then {word:w} step fails                                         # features/steps/subdir_4/subdir_41/nested_steps.py:3
 

--- a/features/step_matcher.cucumber_expressions.feature
+++ b/features/step_matcher.cucumber_expressions.feature
@@ -259,7 +259,6 @@ Feature: Use StepMatcher with CucumberExpressions
               define_parameter_type_with
           )
           from example4me.color import Color
-          from assertpy import assert_that
 
           parse_color = TypeBuilder.make_enum(Color)
           parse_colors = TypeBuilder.with_many(parse_color)
@@ -283,7 +282,7 @@ Feature: Use StepMatcher with CucumberExpressions
           @then('I have selected {int} colo(u)r(s)')
           def step_then_count_selected_colors(ctx, number_of_colors: int):
               assert isinstance(number_of_colors, int)
-              assert_that(ctx.selected_colors).is_length(number_of_colors)
+              assert len(ctx.selected_colors) == number_of_colors
           """
         And a file named "features/many_colors.feature" with:
           """

--- a/features/steps/cucumber_expression_steps.py
+++ b/features/steps/cucumber_expression_steps.py
@@ -4,9 +4,9 @@ Provides some steps for testing step-definitions with `CucumberExpressions`_.
 .. _CucumberExpressions: https://github.com/cucumber/cucumber-expressions
 """
 
+from pytest import approx
 from decimal import Decimal
 from behave import given, when, then
-from assertpy import assert_that
 
 try:
     # -- REQUIRES: Python3, Python.version >= 3.8
@@ -54,69 +54,69 @@ if HAVE_CUCUMBER_EXPRESSIONS:
     @given('I provide a/an "{int}" value as int')
     @when('I provide a/an "{int}" value as int')
     def step_provide_value_as_int(ctx, value):
-        assert_that(value).is_instance_of(int)
-        assert_that(value).is_greater_than_or_equal_to(INT_MIN_VALUE)
-        assert_that(value).is_less_than_or_equal_to(INT_MAX_VALUE)
+        assert type(value) is int
+        assert value >= INT_MIN_VALUE
+        assert value <= INT_MAX_VALUE
         ctx.value = value
 
 
     @given('I provide a/an "{short}" value as short')
     @when('I provide a/an "{short}" value as short')
     def step_provide_value_as_short(ctx, value):
-        assert_that(value).is_instance_of(int)
-        assert_that(value).is_greater_than_or_equal_to(SHORT_MIN_VALUE)
-        assert_that(value).is_less_than_or_equal_to(SHORT_MAX_VALUE)
+        assert type(value) is int
+        assert value >= SHORT_MIN_VALUE
+        assert value <= SHORT_MAX_VALUE
         ctx.value = value
 
 
     @given('I provide a/an "{long}" value as long')
     @when('I provide a/an "{long}" value as long')
     def step_provide_value_as_long(ctx, value):
-        assert_that(value).is_instance_of(int)
-        assert_that(value).is_greater_than_or_equal_to(LONG_MIN_VALUE)
-        assert_that(value).is_less_than_or_equal_to(LONG_MAX_VALUE)
+        assert type(value) is int
+        assert value >= LONG_MIN_VALUE
+        assert value <= LONG_MAX_VALUE
         ctx.value = value
 
 
     @given('I provide a/an "{biginteger}" value as biginteger')
     @when('I provide a/an "{biginteger}" value as biginteger')
     def step_provide_value_as_biginteger(ctx, value):
-        assert_that(value).is_instance_of(int)
+        assert type(value) is int
         ctx.value = value
 
 
     @given('I provide a/an "{byte}" value as byte')
     @when('I provide a/an "{byte}" value as byte')
     def step_provide_value_as_byte(ctx, value):
-        assert_that(value).is_instance_of(int)
-        assert_that(value).is_greater_than_or_equal_to(BYTE_MIN_VALUE)
-        assert_that(value).is_less_than_or_equal_to(BYTE_MAX_VALUE)
+        assert type(value) is int
+        assert value >= BYTE_MIN_VALUE
+        assert value <= BYTE_MAX_VALUE
         ctx.value = value
 
 
     # -- THEN STEPS:
     @then('the stored value equals "{int}" as int')
     def step_then_stored_value_equals_as_int(ctx, expected):
-        assert_that(expected).is_instance_of(int)
-        assert_that(ctx.value).is_equal_to(expected)
+        assert type(expected) is int
+        assert ctx.value == expected
 
 
     @then('the stored value equals "{short}" as short')
     def step_then_stored_value_equals_as_short(ctx, expected):
-        assert_that(expected).is_instance_of(int)
-        assert_that(ctx.value).is_equal_to(expected)
+        assert type(expected) is int
+        assert ctx.value == expected
 
 
     @then('the stored value equals "{long}" as long')
     def step_then_stored_value_equals_as_long(ctx, expected):
-        assert_that(expected).is_instance_of(int)
-        assert_that(ctx.value).is_equal_to(expected)
+        assert type(expected) is int
+        assert ctx.value == expected
 
 
     @then('the stored value equals "{biginteger}" as biginteger')
     def step_then_stored_value_equals_as_biginteger(ctx, expected):
-        assert_that(expected).is_instance_of(int)
-        assert_that(ctx.value).is_equal_to(expected)
+        assert type(expected) is int
+        assert ctx.value == expected
 
 
 # -----------------------------------------------------------------------------
@@ -126,40 +126,41 @@ if HAVE_CUCUMBER_EXPRESSIONS:
     @given('I provide a/an "{float}" value as float')
     @when('I provide a/an "{float}" value as float')
     def step_provide_value_as_float(ctx, value):
-        assert_that(value).is_instance_of(float)
+        assert type(value) is float
         ctx.value = value
 
 
     @given('I provide a/an "{double}" value as double')
     @when('I provide a/an "{double}" value as double')
     def step_provide_value_as_double(ctx, value):
-        assert_that(value).is_instance_of(float)
+        assert type(value) is float
         ctx.value = value
 
 
     @given('I provide a/an "{bigdecimal}" value as bigdecimal')
     @when('I provide a/an "{bigdecimal}" value as bigdecimal')
     def step_provide_value_as_bigdecimal(ctx, value):
-        assert_that(value).is_instance_of(Decimal)
+        assert type(value) is Decimal
         ctx.value = value
 
 
     @then('the stored value equals "{float}" as float')
     def step_then_stored_value_equals_as_float(ctx, expected):
-        assert_that(expected).is_instance_of(float)
-        assert_that(ctx.value).is_close_to(expected, FLOAT_ACCURACY)
+        assert type(expected) is float
+        # ctx.value might be a bigdecimal, so we convert it to float for comparison
+        assert float(ctx.value) == approx(expected, abs=FLOAT_ACCURACY)
 
 
     @then('the stored value equals "{double}" as double')
     def step_then_stored_value_equals_as_double(ctx, expected):
-        assert_that(expected).is_instance_of(float)
-        assert_that(ctx.value).is_close_to(expected, FLOAT_ACCURACY)
+        assert type(expected) is float
+        assert ctx.value == approx(expected, abs=FLOAT_ACCURACY)
 
 
     @then('the stored value equals "{bigdecimal}" as bigdecimal')
     def step_then_stored_value_equals_as_bigdecimal(ctx, expected):
-        assert_that(expected).is_instance_of(Decimal)
-        assert_that(ctx.value).is_close_to(expected, FLOAT_ACCURACY)
+        assert type(expected) is Decimal
+        assert ctx.value == approx(expected, abs=Decimal(str(FLOAT_ACCURACY)))
 
 
 # -----------------------------------------------------------------------------
@@ -169,27 +170,27 @@ if HAVE_CUCUMBER_EXPRESSIONS:
     @given('I provide a/an "{word}" value as word')
     @when('I provide a/an "{word}" value as word')
     def step_provide_value_as_word(ctx, value):
-        assert assert_that(value).is_instance_of(str)
+        assert type(value) is str
         ctx.value = value
 
 
     @given('I provide a/an {string} value as string')
     @when('I provide a/an {string} value as string')
     def step_provide_value_as_string(ctx, value):
-        assert assert_that(value).is_instance_of(str)
+        assert type(value) is str
         ctx.value = value
 
 
     @then('the stored value equals "{word}" as word')
     def step_then_stored_value_equals_as_word(ctx, expected):
-        assert assert_that(expected).is_instance_of(str)
-        assert_that(ctx.value).is_equal_to(expected)
+        assert type(expected) is str
+        assert ctx.value == expected
 
 
     @then('the stored value equals {string} as string')
     def step_then_stored_value_equals_as_string(ctx, expected):
-        assert assert_that(expected).is_instance_of(str)
-        assert_that(ctx.value).is_equal_to(expected)
+        assert type(expected) is str
+        assert ctx.value == expected
 
 
 # -----------------------------------------------------------------------------
@@ -199,11 +200,11 @@ if HAVE_CUCUMBER_EXPRESSIONS:
     @given('I provide a/an "{}" value as any')
     @when('I provide a/an "{}" value as any')
     def step_provide_value_as_any(ctx, value):
-        assert assert_that(value).is_instance_of(str)
+        assert type(value) is str
         ctx.value = value
 
 
     @then('the stored value equals "{}" as any')
     def step_then_stored_value_equals_as_any(ctx, expected):
-        assert assert_that(expected).is_instance_of(str)
-        assert_that(ctx.value).is_equal_to(expected)
+        assert type(expected) is str
+        assert ctx.value == expected

--- a/features/steps/cucumber_expression_steps.py
+++ b/features/steps/cucumber_expression_steps.py
@@ -4,7 +4,7 @@ Provides some steps for testing step-definitions with `CucumberExpressions`_.
 .. _CucumberExpressions: https://github.com/cucumber/cucumber-expressions
 """
 
-from pytest import approx
+from math import isclose
 from decimal import Decimal
 from behave import given, when, then
 
@@ -148,19 +148,19 @@ if HAVE_CUCUMBER_EXPRESSIONS:
     def step_then_stored_value_equals_as_float(ctx, expected):
         assert type(expected) is float
         # ctx.value might be a bigdecimal, so we convert it to float for comparison
-        assert float(ctx.value) == approx(expected, abs=FLOAT_ACCURACY)
+        assert isclose(float(ctx.value), expected, rel_tol=FLOAT_ACCURACY)
 
 
     @then('the stored value equals "{double}" as double')
     def step_then_stored_value_equals_as_double(ctx, expected):
         assert type(expected) is float
-        assert ctx.value == approx(expected, abs=FLOAT_ACCURACY)
+        assert isclose(expected, ctx.value, rel_tol=FLOAT_ACCURACY)
 
 
     @then('the stored value equals "{bigdecimal}" as bigdecimal')
     def step_then_stored_value_equals_as_bigdecimal(ctx, expected):
         assert type(expected) is Decimal
-        assert ctx.value == approx(expected, abs=Decimal(str(FLOAT_ACCURACY)))
+        assert isclose(expected, ctx.value, rel_tol=Decimal(str(FLOAT_ACCURACY)))
 
 
 # -----------------------------------------------------------------------------

--- a/issue.features/issue1180.feature
+++ b/issue.features/issue1180.feature
@@ -27,7 +27,6 @@ Feature: Issue #1180 -- Negative Time Problem with Summary Reporter
       from behave import given, when, then
       from freezegun import freeze_time
       import freezegun
-      from assertpy import assert_that
 
       FREEZEGUN_IGNORE_BEHAVE = os.environ.get("FREEZEGUN_IGNORE_BEHAVE", "no") == "yes"
       if FREEZEGUN_IGNORE_BEHAVE:
@@ -48,7 +47,7 @@ Feature: Issue #1180 -- Negative Time Problem with Summary Reporter
       @then('today is "{today:ti}"')
       def step_then_today_is(ctx, today):
           now = datetime.datetime.now()
-          assert_that(today).is_equal_to(now)
+          assert today == now
       """
     And a file named "features/syndrome_1180.feature" with:
       """

--- a/issue.features/steps/encoding_steps.py
+++ b/issue.features/steps/encoding_steps.py
@@ -50,7 +50,7 @@ def _setup_console_encoding_on_windows(encoding, language=None):
 
     os.environ["PYTHONIOENCODING"] = encoding
     result = os.system("chcp {code_page}".format(code_page=code_page))
-    assert result is 0
+    assert result == 0
 
 
 def _setup_console_encoding_on_posix(encoding, language=None):
@@ -97,4 +97,4 @@ def step_chardet_file_encoding_should_be(ctx, filename, encoding):
     workdir_filename = realpath_with_context(filename, ctx)
     contents_as_bytes = Path(workdir_filename).read_bytes()
     actual_data = chardet.detect(contents_as_bytes)
-    assert actual_data["encoding"] is encoding
+    assert actual_data["encoding"] == encoding

--- a/issue.features/steps/encoding_steps.py
+++ b/issue.features/steps/encoding_steps.py
@@ -7,7 +7,6 @@ from behave.fixture import fixture, use_fixture
 from behave.parameter_type import parse_unquoted_text
 from behave4cmd0.pathutil import realpath_with_context
 import chardet
-from assertpy import assert_that
 
 
 # -----------------------------------------------------------------------------
@@ -51,7 +50,7 @@ def _setup_console_encoding_on_windows(encoding, language=None):
 
     os.environ["PYTHONIOENCODING"] = encoding
     result = os.system("chcp {code_page}".format(code_page=code_page))
-    assert_that(result).is_equal_to(0)
+    assert result is 0
 
 
 def _setup_console_encoding_on_posix(encoding, language=None):
@@ -98,4 +97,4 @@ def step_chardet_file_encoding_should_be(ctx, filename, encoding):
     workdir_filename = realpath_with_context(filename, ctx)
     contents_as_bytes = Path(workdir_filename).read_bytes()
     actual_data = chardet.detect(contents_as_bytes)
-    assert_that(actual_data["encoding"]).is_equal_to(encoding)
+    assert actual_data["encoding"] is encoding

--- a/more.features/steps/tutorial_steps.py
+++ b/more.features/steps/tutorial_steps.py
@@ -18,4 +18,4 @@ def step_impl(context):
 
 @then('behave will test it for us!')
 def step_impl(context):
-    assert True is not False
+    assert not context.failed

--- a/more.features/steps/tutorial_steps.py
+++ b/more.features/steps/tutorial_steps.py
@@ -4,7 +4,6 @@ Step implementations for tutorial example.
 """
 
 from behave import given, when, then
-from assertpy import assert_that
 
 
 @given('we have behave installed')
@@ -14,9 +13,9 @@ def step_impl(context):
 
 @when('we implement a test')
 def step_impl(context):
-    assert_that(True).is_not_equal_to(False)
+    assert True is not False
 
 
 @then('behave will test it for us!')
 def step_impl(context):
-    assert_that(context.failed).is_equal_to(False)
+    assert True is not False

--- a/py.requirements/testing.txt
+++ b/py.requirements/testing.txt
@@ -11,7 +11,6 @@ pytest-html >= 2.0; python_version >= '3.0'
 
 # -- ASSERT-MATCHER:
 PyHamcrest >= 2.0.2; python_version >= '3.0'
-assertpy >= 1.1
 
 chardet
 # PREPARED: charset-normalizer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,6 @@ testing = [
     "pytest >= 5.0; python_version >= '3.0'",
     "pytest-html >= 2.0;         python_version >= '3.0'",
     "PyHamcrest >= 2.0.2; python_version >= '3.0'",
-    "assertpy >= 1.1",
     "chardet",
     "charset-normalizer",
 

--- a/tests/functional/_test_async_step.py
+++ b/tests/functional/_test_async_step.py
@@ -15,7 +15,6 @@ from behave.runner import Context, Runner
 
 # -- IMPORTS:
 # from hamcrest import assert_that, close_to, equal_to
-from assertpy import assert_that
 import pytest
 
 # MAYBE: from tests.api.testing_support import StopWatch
@@ -106,7 +105,7 @@ class TestAsyncStepFunction:
         ctx = Context(runner=Runner(config={}))
         ctx.called = []
         async_step_function(ctx, value=10)
-        assert_that(ctx.called).is_equal_to(["coroutine_function_3_with_10"])
+        assert ctx.called == ["coroutine_function_3_with_10"]
 
     def test_async_step_correctly(self):
         step_container = SimpleStepContainer()
@@ -137,7 +136,7 @@ class TestUseAsyncStep:
             async def async_step_is_called(ctx):
                 ctx.called.append("async_step_is_called")
                 actual_value = await async_plus_two(10)
-                assert_that(actual_value).is_equal_to(12)
+                assert actual_value == 12
 
         # pylint: enable=import-outside-toplevel, unused-argument
         # -- USES: async def step_impl(...) as async-step (coroutine)
@@ -149,7 +148,7 @@ class TestUseAsyncStep:
         ctx.called = []
         async_step_is_called(ctx)
         assert isinstance(async_step_is_called, AsyncStepFunction)
-        assert_that(ctx.called).is_equal_to(["async_step_is_called"])
+        assert ctx.called == ["async_step_is_called"]
 
     def test_async_step_with_params_can_be_called(self):
         step_container = SimpleStepContainer()
@@ -162,14 +161,14 @@ class TestUseAsyncStep:
                 assert isinstance(value, int)
                 ctx.called.append(f"async_step_is_called_with_{value}")
                 actual_value = await async_plus_two(value)
-                assert_that(actual_value).is_equal_to(value + 2)
+                assert actual_value is value + 2
 
         # -- RUN ASYNC-STEP: Verify that it is behaving correctly.
         # ENSURE: Execution of async-step matches expected duration.
         ctx = Context(runner=Runner(config={}))
         ctx.called = []
         async_step_with_params(ctx, 10)
-        assert_that(ctx.called).is_equal_to(["async_step_is_called_with_10"])
+        assert ctx.called == ["async_step_is_called_with_10"]
 
     def test_outcome_passed(self):
         step_container = SimpleStepContainer()
@@ -180,7 +179,7 @@ class TestUseAsyncStep:
             @step('an async-step should have "{name}')
             async def async_step_passes(ctx, name: str):
                 actual_name = ctx.name
-                assert_that(name).is_equal_to(actual_name)
+                assert name is actual_name
 
         # -- RUN ASYNC-STEP: Verify that it is behaving correctly.
         ctx = Context(runner=Runner(config={}))
@@ -196,7 +195,7 @@ class TestUseAsyncStep:
             @step('an async-step should have "{name}')
             async def async_step_fails(ctx, name: str):
                 actual_name = ctx.name
-                assert_that(name).is_equal_to(actual_name)
+                assert name is actual_name
 
         # -- RUN ASYNC-STEP: Verify that it is behaving correctly.
         ctx = Context(runner=Runner(config={}))
@@ -244,7 +243,7 @@ class TestUseAsyncStep:
         policy = asyncio.get_event_loop_policy()
         monkeypatch.setattr(policy, "get_event_loop", mock_get_event_loop)
         async_step_1(ctx, "ASYNC_STEP_1")
-        assert_that(ctx.called).is_equal_to(["EVENTLOOP_RUNTIME_ERROR", "HELLO ASYNC_STEP_1"])
+        assert ctx.called == ["EVENTLOOP_RUNTIME_ERROR", "HELLO ASYNC_STEP_1"]
 
     def test_event_loop_exists(self):
         step_container = SimpleStepContainer()
@@ -266,7 +265,7 @@ class TestUseAsyncStep:
         ctx = Context(runner=Runner(config={}))
         ctx.called = []
         async_step_2(ctx, "ASYNC_STEP_2")
-        assert_that(ctx.called).is_equal_to(["HELLO ASYNC_STEP_2"])
+        assert ctx.called == ["HELLO ASYNC_STEP_2"]
 
 
 @pytest.mark.skipif(not PythonLibraryFeature.has_asyncio_timeout(),
@@ -287,7 +286,7 @@ class TestAsyncStepFunctionWithTimeout:
         ctx = Context(runner=Runner(config={}))
         ctx.called = []
         async_step_with_timeout(ctx, "ASYNC_STEP_1")
-        assert_that(ctx.called).is_equal_to(["HELLO ASYNC_STEP_1"])
+        assert ctx.called == ["HELLO ASYNC_STEP_1"]
 
     def test_with_timeout_if_timeout_occurs_as_error(self):
         step_container = SimpleStepContainer()

--- a/tests/functional/_test_async_step.py
+++ b/tests/functional/_test_async_step.py
@@ -161,7 +161,7 @@ class TestUseAsyncStep:
                 assert isinstance(value, int)
                 ctx.called.append(f"async_step_is_called_with_{value}")
                 actual_value = await async_plus_two(value)
-                assert actual_value is value + 2
+                assert actual_value == value + 2
 
         # -- RUN ASYNC-STEP: Verify that it is behaving correctly.
         # ENSURE: Execution of async-step matches expected duration.
@@ -179,7 +179,7 @@ class TestUseAsyncStep:
             @step('an async-step should have "{name}')
             async def async_step_passes(ctx, name: str):
                 actual_name = ctx.name
-                assert name is actual_name
+                assert name == actual_name
 
         # -- RUN ASYNC-STEP: Verify that it is behaving correctly.
         ctx = Context(runner=Runner(config={}))
@@ -195,7 +195,7 @@ class TestUseAsyncStep:
             @step('an async-step should have "{name}')
             async def async_step_fails(ctx, name: str):
                 actual_name = ctx.name
-                assert name is actual_name
+                assert name == actual_name
 
         # -- RUN ASYNC-STEP: Verify that it is behaving correctly.
         ctx = Context(runner=Runner(config={}))

--- a/tests/functional/_test_async_step_decorator.py
+++ b/tests/functional/_test_async_step_decorator.py
@@ -8,7 +8,6 @@ REQUIRES: Python version >= 3.5
 import asyncio
 import sys
 import pytest
-from assertpy import assert_that
 
 from behave._stepimport import use_step_import_modules, SimpleStepContainer
 from behave.async_step import AsyncStepFunction, StepFunctionTypeError
@@ -54,7 +53,7 @@ class TestUseAsyncStepDecorator:
             async def async_step_is_called(ctx):
                 ctx.called.append("async_step_is_called")
                 actual_value = await async_plus_two(10)
-                assert_that(actual_value).is_equal_to(12)
+                assert actual_value == 12
 
         # pylint: enable=import-outside-toplevel, unused-argument
         # -- USES: async def step_impl(...) as async-step (coroutine)
@@ -66,7 +65,7 @@ class TestUseAsyncStepDecorator:
         ctx.called = []
         async_step_is_called(ctx)
         assert isinstance(async_step_is_called, AsyncStepFunction)
-        assert_that(ctx.called).is_equal_to(["async_step_is_called"])
+        assert ctx.called == ["async_step_is_called"]
 
     def test_async_step_with_decorator_params(self):
         step_container = SimpleStepContainer()
@@ -80,7 +79,7 @@ class TestUseAsyncStepDecorator:
             async def async_step_is_called(ctx):
                 ctx.called.append("async_step_is_called")
                 actual_value = await async_plus_two(10)
-                assert_that(actual_value).is_equal_to(12)
+                assert actual_value == 12
 
         # pylint: enable=import-outside-toplevel, unused-argument
         # -- USES: async def step_impl(...) as async-step (coroutine)
@@ -92,7 +91,7 @@ class TestUseAsyncStepDecorator:
         ctx.called = []
         async_step_is_called(ctx)
         assert isinstance(async_step_is_called, AsyncStepFunction)
-        assert_that(ctx.called).is_equal_to(["async_step_is_called"])
+        assert ctx.called == ["async_step_is_called"]
 
     def test_sync_step_with_decorator_raises_step_error(self):
         step_container = SimpleStepContainer()
@@ -123,14 +122,14 @@ class TestUseAsyncStepDecorator:
                 assert isinstance(value, int)
                 ctx.called.append(f"async_step_is_called_with_{value}")
                 actual_value = await async_plus_two(value)
-                assert_that(actual_value).is_equal_to(value + 2)
+                assert actual_value is value + 2
 
         # -- RUN ASYNC-STEP: Verify that it is behaving correctly.
         # ENSURE: Execution of async-step matches expected duration.
         ctx = Context(runner=Runner(config={}))
         ctx.called = []
         async_step_with_params(ctx, 10)
-        assert_that(ctx.called).is_equal_to(["async_step_is_called_with_10"])
+        assert ctx.called == ["async_step_is_called_with_10"]
 
     def test_outcome_passed(self):
         step_container = SimpleStepContainer()
@@ -143,7 +142,7 @@ class TestUseAsyncStepDecorator:
             @async_run_until_complete
             async def async_step_passes(ctx, name: str):
                 actual_name = ctx.name
-                assert_that(name).is_equal_to(actual_name)
+                assert name is actual_name
 
         # -- RUN ASYNC-STEP: Verify that it is behaving correctly.
         ctx = Context(runner=Runner(config={}))
@@ -161,7 +160,7 @@ class TestUseAsyncStepDecorator:
             @async_run_until_complete
             async def async_step_fails(ctx, name: str):
                 actual_name = ctx.name
-                assert_that(name).is_equal_to(actual_name)
+                assert name is actual_name
 
         # -- RUN ASYNC-STEP: Verify that it is behaving correctly.
         ctx = Context(runner=Runner(config={}))
@@ -213,7 +212,7 @@ class TestUseAsyncStepDecorator:
         policy = asyncio.get_event_loop_policy()
         monkeypatch.setattr(policy, "get_event_loop", mock_get_event_loop)
         async_step_1(ctx, "ASYNC_STEP_1")
-        assert_that(ctx.called).is_equal_to(["EVENTLOOP_RUNTIME_ERROR", "HELLO ASYNC_STEP_1"])
+        assert ctx.called == ["EVENTLOOP_RUNTIME_ERROR", "HELLO ASYNC_STEP_1"]
 
     def test_event_loop_exists(self):
         step_container = SimpleStepContainer()
@@ -237,7 +236,7 @@ class TestUseAsyncStepDecorator:
         ctx = Context(runner=Runner(config={}))
         ctx.called = []
         async_step_2(ctx, "ASYNC_STEP_2")
-        assert_that(ctx.called).is_equal_to(["HELLO ASYNC_STEP_2"])
+        assert ctx.called == ["HELLO ASYNC_STEP_2"]
 
 
 @pytest.mark.skipif(not PythonLibraryFeature.has_asyncio_timeout(),
@@ -261,7 +260,7 @@ class TestUseAsyncStepDecoratorWithTimeout:
         ctx = Context(runner=Runner(config={}))
         ctx.called = []
         async_step_with_timeout(ctx, "ASYNC_STEP_1")
-        assert_that(ctx.called).is_equal_to(["HELLO ASYNC_STEP_1"])
+        assert ctx.called == ["HELLO ASYNC_STEP_1"]
 
     def test_with_timeout_if_timeout_occurs(self):
         step_container = SimpleStepContainer()

--- a/tests/functional/_test_async_step_decorator.py
+++ b/tests/functional/_test_async_step_decorator.py
@@ -122,7 +122,7 @@ class TestUseAsyncStepDecorator:
                 assert isinstance(value, int)
                 ctx.called.append(f"async_step_is_called_with_{value}")
                 actual_value = await async_plus_two(value)
-                assert actual_value is value + 2
+                assert actual_value == value + 2
 
         # -- RUN ASYNC-STEP: Verify that it is behaving correctly.
         # ENSURE: Execution of async-step matches expected duration.
@@ -142,7 +142,7 @@ class TestUseAsyncStepDecorator:
             @async_run_until_complete
             async def async_step_passes(ctx, name: str):
                 actual_name = ctx.name
-                assert name is actual_name
+                assert name == actual_name
 
         # -- RUN ASYNC-STEP: Verify that it is behaving correctly.
         ctx = Context(runner=Runner(config={}))
@@ -160,7 +160,7 @@ class TestUseAsyncStepDecorator:
             @async_run_until_complete
             async def async_step_fails(ctx, name: str):
                 actual_name = ctx.name
-                assert name is actual_name
+                assert name == actual_name
 
         # -- RUN ASYNC-STEP: Verify that it is behaving correctly.
         ctx = Context(runner=Runner(config={}))

--- a/tests/issues/test_issue1054.py
+++ b/tests/issues/test_issue1054.py
@@ -6,7 +6,6 @@ from behave.__main__ import run_behave
 from behave.configuration import Configuration
 from behave.tag_expression.builder import make_tag_expression
 import pytest
-from assertpy import assert_that
 
 
 def test_syndrome_with_core(capsys):
@@ -35,5 +34,5 @@ def test_syndrome_functional(tags_option, capsys):
     captured = capsys.readouterr()
     expected_part1 = "CURRENT TAG_EXPRESSION: ((fish or fries) and (beer and water))"
     expected_part2 = "means: And(Or(Tag('fish'), Tag('fries')), And(Tag('beer'), Tag('water')))"
-    assert_that(captured.out).contains(expected_part1)
-    assert_that(captured.out).contains(expected_part2)
+    assert expected_part1 in captured.out
+    assert expected_part2 in captured.out

--- a/tests/unit/test_cucumber_expression.py
+++ b/tests/unit/test_cucumber_expression.py
@@ -11,7 +11,6 @@ from enum import Enum
 
 import parse
 import pytest
-# MAYBE: from assertpy import assert_that
 
 try:
     # -- REQUIRES: Python3, Python.version >= 3.8  (probably)

--- a/tools/test-features/steps/steps.py
+++ b/tools/test-features/steps/steps.py
@@ -1,7 +1,6 @@
 # ruff: noqa: F811
 import logging
 from behave import given, when, then, register_type
-from assertpy import assert_that
 
 
 spam_log = logging.getLogger('spam')
@@ -20,8 +19,8 @@ def step_impl(context):
 
 @given("stuff has been set up")
 def step_impl(context):
-    assert_that(context.testing_stuff).is_equal_to(True)
-    assert_that(context.stuff_set_up).is_equal_to(True)
+    assert context.testing_stuff is True
+    assert context.stuff_set_up is True
 
 
 @when("I exercise it work")
@@ -47,7 +46,7 @@ def step_impl(context, suffix):
 
 @then('we should get the {combination}')
 def step_impl(context, combination):
-    assert_that(context.combination).is_equal_to(combination)
+    assert context.combination == combination
 
 
 @given('some body of text')
@@ -66,7 +65,7 @@ nisi ut aliquip ex ea commodo consequat.'''
 @then('the text is as expected')
 def step_impl(context):
     assert context.saved_text, 'context.saved_text is %r!!' % (context.saved_text, )
-    assert_that(context.saved_text).is_equal_to(TEXT)
+    assert context.saved_text == TEXT
 
 
 @given('some initial data')
@@ -87,15 +86,15 @@ TABLE_DATA = [
 def step_impl(context):
     assert context.saved_table, 'context.saved_table is %r!!' % (context.saved_table, )
     for expected, got in zip(TABLE_DATA, iter(context.saved_table)):
-        assert_that(expected["name"]).is_equal_to(got["name"])
-        assert_that(expected["department"]).is_equal_to(got["department"])
+        assert expected["name"] == got["name"]
+        assert expected["department"] == got["department"]
 
 
 @then('the text is substituted as expected')
 def step_impl(context):
     assert context.saved_text, 'context.saved_text is %r!!' % (context.saved_text, )
     expected = TEXT.replace('ipsum', context.active_outline['ipsum'])
-    assert_that(context.saved_text).is_equal_to(expected)
+    assert context.saved_text == expected
 
 
 TABLE_DATA = [
@@ -141,5 +140,5 @@ def step_impl(context, argument):
 
 @then('we get "{argument}" parsed')
 def step_impl(context, argument):
-    assert_that(context.argument).is_equal_to(argument)
+    assert context.argument == argument
 


### PR DESCRIPTION
Fix for this "issue": https://github.com/behave/behave/issues/1311

Had some time to kill and removed the `assertpy` dependency (except the `soft_assertion` example). Maybe you can have a look and tell me what you think. 

BR