### PR TITLE
Fix: ResourceWarning on python 3.12 and remove deprecated usage of codecs

### DIFF
--- a/behave/reporter/junit.py
+++ b/behave/reporter/junit.py
@@ -69,7 +69,6 @@ Best sources are:
 # pylint: enable=line-too-long
 
 import os.path
-import codecs
 import re
 import sys
 import traceback
@@ -299,7 +298,8 @@ class JUnitReporter(Reporter):
         report_dirname = self.config.junit_directory
         report_basename = 'TESTS-%s.xml' % feature_filename
         report_filename = os.path.join(report_dirname, report_basename)
-        tree.write(codecs.open(report_filename, "wb"), "UTF-8")
+        with open(report_filename, "wb") as f:
+            tree.write(f, "UTF-8")
 
     # -- MORE:
     # pylint: disable=line-too-long

--- a/tests/unit/reporter/conftest.py
+++ b/tests/unit/reporter/conftest.py
@@ -1,0 +1,31 @@
+"""Shared fixtures for reporter tests."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from behave.model import Feature
+from behave.model_type import Status
+
+
+@pytest.fixture
+def mock_config(tmp_path):
+    config = Mock()
+    config.junit_directory = str(tmp_path)
+    config.paths = []
+    config.base_dir = "."
+    config.userdata = {}
+    config.show_skipped = True
+    return config
+
+
+@pytest.fixture
+def feature():
+    feature = Feature(
+        filename="features/test.feature",
+        line=1,
+        keyword="Feature",
+        name="Test Feature",
+    )
+    feature._status = Status.passed
+    return feature

--- a/tests/unit/reporter/test_junit.py
+++ b/tests/unit/reporter/test_junit.py
@@ -1,0 +1,29 @@
+"""Tests for JUnitReporter."""
+
+from unittest.mock import patch, mock_open
+
+from behave.reporter.junit import JUnitReporter
+
+
+def test_feature_closes_report_file(mock_config, feature):
+    """Verify the report file handle is deterministically closed."""
+    reporter = JUnitReporter(mock_config)
+    m = mock_open()
+
+    with patch("builtins.open", m):
+        reporter.feature(feature)
+
+    handle = m()
+    handle.__exit__.assert_called()
+
+
+def test_feature_writes_report_file(mock_config, feature, tmp_path):
+    """Verify the report file is actually written."""
+    reporter = JUnitReporter(mock_config)
+
+    reporter.feature(feature)
+
+    report_files = list(tmp_path.glob("TESTS-*.xml"))
+    assert len(report_files) == 1
+    content = report_files[0].read_bytes()
+    assert b"Test Feature" in content


### PR DESCRIPTION
JUnitReporter.feature() opens the XML output file with codecs.open() but never
closes it. This causes a ResourceWarning on Python 3.12+ and will break on Python 3.14,
where codecs.open() is deprecated.

This PR fixes both issues with a one-line change.

[Issue](https://github.com/behave/behave/issues/1313)