### PR TITLE
feat: add --fail-focus CLI parameter

### DIFF
--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -410,6 +410,12 @@ Only tag-expressions v2 are supported (since: behave v1.4.0).
                   "plain" formatter, do not capture stdout or logging output
                   and stop at the first failure.""")),
 
+    (("--fail-focus",),
+     dict(action="store_true",
+          help="""Focus on the first failure only. Additionally: use the
+                  "fail_focus" formatter, stop at the first failure,
+                  and do not show snippets for undefined steps.""")),
+
     (("--lang",),
      dict(metavar="LANG",
           help="Use keywords for a language other than English.")),
@@ -825,6 +831,8 @@ class Configuration:
             self.setup_steps_catalog_mode()
         if self.wip:
             self.setup_wip_mode()
+        if self.fail_focus:
+            self.setup_fail_focus_mode()
         if self.quiet:
             self.show_source = False
             self.show_snippets = False
@@ -872,6 +880,7 @@ class Configuration:
         self.default_tags = None
         self.userdata = None
         self.wip = None
+        self.fail_focus = None
         self.verbose = verbose or False
         self.formatters = []
         self.reporters = []
@@ -967,6 +976,21 @@ class Configuration:
             self.tags = f"@wip and {self.tags}"
         else:
             self.tags = "@wip"
+
+    def setup_fail_focus_mode(self):
+        # Focus on first failure only.
+        # Additionally:
+        #  * use the "fail_focus" formatter (per default)
+        #  * stop at the first failure
+        #  * do not show snippets for undefined steps
+        self.default_format = "fail_focus"
+        self.format = self.format or []
+        if self.format:
+            self.format.append("fail_focus")
+        else:
+            self.format = ["fail_focus"]
+        self.stop = True
+        self.show_snippets = False
 
     def setup_steps_catalog_mode(self):
         # -- SHOW STEP-CATALOG: As step summary.

--- a/behave/configuration.py
+++ b/behave/configuration.py
@@ -414,7 +414,8 @@ Only tag-expressions v2 are supported (since: behave v1.4.0).
      dict(action="store_true",
           help="""Focus on the first failure only. Additionally: use the
                   "fail_focus" formatter, stop at the first failure,
-                  and do not show snippets for undefined steps.""")),
+                  do not show snippets for undefined steps,
+                  and do not display the summary.""")),
 
     (("--lang",),
      dict(metavar="LANG",
@@ -991,6 +992,7 @@ class Configuration:
             self.format = ["fail_focus"]
         self.stop = True
         self.show_snippets = False
+        self.summary = False
 
     def setup_steps_catalog_mode(self):
         # -- SHOW STEP-CATALOG: As step summary.

--- a/behave/formatter/_builtins.py
+++ b/behave/formatter/_builtins.py
@@ -31,6 +31,7 @@ _BUILTIN_FORMATS = [
     ("steps.usage",   "behave.formatter.steps:StepsUsageFormatter"),
     ("sphinx.steps",  "behave.formatter.sphinx_steps:SphinxStepsFormatter"),
     ("captured", "behave.formatter.captured:CapturedFormatter"),
+    ("fail_focus", "behave.formatter.fail_focus:FailFocusFormatter"),
 ]
 
 

--- a/behave/formatter/fail_focus.py
+++ b/behave/formatter/fail_focus.py
@@ -5,10 +5,10 @@ from behave.model_type import Status
 
 
 class FailFocusFormatter(Formatter):
-    """Only shows the first failing scenario with error details."""
+    """Only shows failing scenarios with error details."""
 
     name = "fail_focus"
-    description = "Only shows the first failing scenario with error details."
+    description = "Only shows failing scenarios with error details."
 
     def __init__(self, stream_opener, config, **kwargs):
         super(FailFocusFormatter, self).__init__(stream_opener, config)
@@ -17,9 +17,11 @@ class FailFocusFormatter(Formatter):
         self.current_scenario = None
         self.steps = []
         self._has_failure = False
+        self._feature_printed = False
 
     def feature(self, feature):
         self.current_feature = feature
+        self._feature_printed = False
 
     def scenario(self, scenario):
         self._flush()
@@ -37,7 +39,7 @@ class FailFocusFormatter(Formatter):
                 self.steps[i] = step
                 break
 
-        if step.status == Status.failed:
+        if step.status.has_failed():
             self._has_failure = True
 
     def _flush(self):
@@ -48,8 +50,11 @@ class FailFocusFormatter(Formatter):
         feature = self.current_feature
         scenario = self.current_scenario
 
-        self.stream.write("Feature: %s -- %s\n" % (feature.name, feature.filename))
-        self.stream.write("\n")
+        if not self._feature_printed:
+            self.stream.write("Feature: %s -- %s\n" % (feature.name, feature.filename))
+            self.stream.write("\n")
+            self._feature_printed = True
+
         self.stream.write("  Scenario: %s  -- %s:%s\n" % (
             scenario.name, scenario.location.filename, scenario.location.line))
 

--- a/behave/formatter/fail_focus.py
+++ b/behave/formatter/fail_focus.py
@@ -1,0 +1,75 @@
+"""FailFocusFormatter -- Only shows output for scenarios that have a failed step."""
+
+from behave.formatter.base import Formatter
+from behave.model_type import Status
+
+
+class FailFocusFormatter(Formatter):
+    """Only shows the first failing scenario with error details."""
+
+    name = "fail_focus"
+    description = "Only shows the first failing scenario with error details."
+
+    def __init__(self, stream_opener, config, **kwargs):
+        super(FailFocusFormatter, self).__init__(stream_opener, config)
+        self.stream = self.open()
+        self.current_feature = None
+        self.current_scenario = None
+        self.steps = []
+        self._has_failure = False
+
+    def feature(self, feature):
+        self.current_feature = feature
+
+    def scenario(self, scenario):
+        self._flush()
+        self.current_scenario = scenario
+        self.steps = []
+        self._has_failure = False
+
+    def step(self, step):
+        self.steps.append(step)
+
+    def result(self, step):
+        # Update the step in the buffer with its result
+        for i, s in enumerate(self.steps):
+            if s is step:
+                self.steps[i] = step
+                break
+
+        if step.status == Status.failed:
+            self._has_failure = True
+
+    def _flush(self):
+        """Write buffered scenario output to stream."""
+        if not self._has_failure:
+            return
+
+        feature = self.current_feature
+        scenario = self.current_scenario
+
+        self.stream.write("Feature: %s -- %s\n" % (feature.name, feature.filename))
+        self.stream.write("\n")
+        self.stream.write("  Scenario: %s  -- %s:%s\n" % (
+            scenario.name, scenario.location.filename, scenario.location.line))
+
+        for step in self.steps:
+            self.stream.write("    %s %s ... %s\n" % (
+                step.keyword, step.name, step.status.name))
+
+        # Write error messages
+        for step in self.steps:
+            if step.error_message:
+                self.stream.write("%s\n" % step.error_message)
+
+        self._has_failure = False
+        self.steps = []
+
+    def eof(self):
+        self._flush()
+        self.current_feature = None
+        self.current_scenario = None
+        self.steps = []
+
+    def close(self):
+        self.close_stream()

--- a/behave/formatter/fail_focus.py
+++ b/behave/formatter/fail_focus.py
@@ -39,7 +39,7 @@ class FailFocusFormatter(Formatter):
                 self.steps[i] = step
                 break
 
-        if step.status.has_failed():
+        if step.status in (Status.failed, Status.error, Status.hook_error):
             self._has_failure = True
 
     def _flush(self):

--- a/docs/superpowers/plans/2026-04-01-fail-focus.md
+++ b/docs/superpowers/plans/2026-04-01-fail-focus.md
@@ -1,0 +1,437 @@
+# `--fail-focus` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `--fail-focus` CLI parameter that stops on first failure and only outputs the failing scenario with its Feature header, steps, and traceback — suppressing passed/undefined/skipped scenarios.
+
+**Architecture:** New `FailFocusFormatter` registered as `fail_focus` in the formatter registry. The `--fail-focus` flag in `Configuration` triggers `setup_fail_focus_mode()` which sets `stop=True`, `show_snippets=False`, and overrides the default formatter to `fail_focus`. The formatter buffers feature/scenario/step data and only flushes output when a scenario fails.
+
+**Tech Stack:** Python, behave formatter API (`behave.formatter.base.Formatter`)
+
+---
+
+### Task 1: Create FailFocusFormatter
+
+**Files:**
+- Create: `behave/formatter/fail_focus.py`
+- Test: `tests/unit/test_formatter_fail_focus.py`
+
+- [ ] **Step 1: Write the failing test for FailFocusFormatter — passed scenario is silent**
+
+```python
+# tests/unit/test_formatter_fail_focus.py
+import io
+import unittest
+from unittest.mock import Mock
+from behave.formatter.base import StreamOpener
+from behave.model import Feature, Scenario, Step
+from behave.model_type import Status
+
+
+def make_config(**kwargs):
+    config = Mock()
+    config.show_timings = kwargs.get("show_timings", False)
+    config.show_multiline = kwargs.get("show_multiline", True)
+    config.show_source = kwargs.get("show_source", False)
+    config.color = "off"
+    return config
+
+
+def make_stream_opener():
+    stream = io.StringIO()
+    return StreamOpener(stream=stream), stream
+
+
+class TestFailFocusFormatter(unittest.TestCase):
+    def _make_formatter(self, **config_kwargs):
+        from behave.formatter.fail_focus import FailFocusFormatter
+        stream_opener, stream = make_stream_opener()
+        config = make_config(**config_kwargs)
+        formatter = FailFocusFormatter(stream_opener, config)
+        return formatter, stream
+
+    def _make_feature(self, name="Test Feature", filename="features/test.feature"):
+        feature = Mock()
+        feature.keyword = "Feature"
+        feature.name = name
+        feature.filename = filename
+        feature.tags = []
+        feature.location = Mock()
+        feature.location.filename = filename
+        feature.location.line = 1
+        return feature
+
+    def _make_scenario(self, name="Test Scenario", filename="features/test.feature", line=5):
+        scenario = Mock()
+        scenario.keyword = "Scenario"
+        scenario.name = name
+        scenario.filename = filename
+        scenario.tags = []
+        scenario.location = Mock()
+        scenario.location.filename = filename
+        scenario.location.line = line
+        return scenario
+
+    def _make_step(self, keyword="Given", name="a step", status=Status.passed,
+                   error_message=None, duration=0):
+        step = Mock()
+        step.keyword = keyword
+        step.name = name
+        step.status = status
+        step.error_message = error_message
+        step.duration = duration
+        step.text = None
+        step.table = None
+        return step
+
+    def test_passed_scenario_produces_no_output(self):
+        formatter, stream = self._make_formatter()
+        feature = self._make_feature()
+        scenario = self._make_scenario()
+        step = self._make_step(status=Status.passed)
+
+        formatter.feature(feature)
+        formatter.scenario(scenario)
+        formatter.step(step)
+        formatter.result(step)
+        formatter.eof()
+        formatter.close()
+
+        self.assertEqual(stream.getvalue(), "")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/unit/test_formatter_fail_focus.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'behave.formatter.fail_focus'`
+
+- [ ] **Step 3: Write FailFocusFormatter — minimal implementation for passed scenario silence**
+
+```python
+# behave/formatter/fail_focus.py
+"""
+Formatter that only outputs the first failing scenario.
+Used with --fail-focus mode.
+"""
+
+from behave.formatter.base import Formatter
+from behave.model_type import Status
+
+
+class FailFocusFormatter(Formatter):
+    name = "fail_focus"
+    description = "Only shows the first failing scenario with error details."
+
+    def __init__(self, stream_opener, config):
+        super(FailFocusFormatter, self).__init__(stream_opener, config)
+        self.current_feature = None
+        self.current_scenario = None
+        self.current_steps = []
+        self.feature_printed = False
+        self.stream = self.open()
+
+    def feature(self, feature):
+        self.current_feature = feature
+        self.feature_printed = False
+
+    def scenario(self, scenario):
+        self.current_scenario = scenario
+        self.current_steps = []
+
+    def step(self, step):
+        self.current_steps.append(step)
+
+    def result(self, step):
+        # Update stored step with result
+        for i, s in enumerate(self.current_steps):
+            if s is step:
+                self.current_steps[i] = step
+                break
+
+        if step.status in (Status.failed, Status.error):
+            self._print_failure()
+
+    def _print_failure(self):
+        if not self.feature_printed and self.current_feature:
+            self.stream.write("Feature: %s -- %s\n" % (
+                self.current_feature.name,
+                self.current_feature.filename
+            ))
+            self.feature_printed = True
+
+        if self.current_scenario:
+            self.stream.write("\n  Scenario: %s  -- %s:%s\n" % (
+                self.current_scenario.name,
+                self.current_scenario.location.filename,
+                self.current_scenario.location.line
+            ))
+
+        for s in self.current_steps:
+            status_text = s.status.name
+            self.stream.write("    %s %s ... %s\n" % (
+                s.keyword, s.name, status_text
+            ))
+            if s.error_message:
+                self.stream.write("%s\n" % s.error_message)
+
+        self.stream.flush()
+
+    def eof(self):
+        pass
+
+    def close(self):
+        self.close_stream()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/unit/test_formatter_fail_focus.py::TestFailFocusFormatter::test_passed_scenario_produces_no_output -v`
+Expected: PASS
+
+- [ ] **Step 5: Write test for failed scenario output**
+
+Add to `tests/unit/test_formatter_fail_focus.py`:
+
+```python
+    def test_failed_scenario_outputs_feature_and_scenario_with_error(self):
+        formatter, stream = self._make_formatter()
+        feature = self._make_feature(name="User login", filename="features/login.feature")
+        scenario = self._make_scenario(name="Login with wrong password",
+                                       filename="features/login.feature", line=15)
+        step1 = self._make_step(keyword="Given", name='a registered user "alice"',
+                                status=Status.passed)
+        step2 = self._make_step(keyword="Then", name="she should see an error",
+                                status=Status.failed,
+                                error_message="Assertion Failed: Expected error message")
+
+        formatter.feature(feature)
+        formatter.scenario(scenario)
+        formatter.step(step1)
+        formatter.step(step2)
+        formatter.result(step1)
+        formatter.result(step2)
+        formatter.eof()
+        formatter.close()
+
+        output = stream.getvalue()
+        self.assertIn("Feature: User login -- features/login.feature", output)
+        self.assertIn("Scenario: Login with wrong password", output)
+        self.assertIn("features/login.feature:15", output)
+        self.assertIn("Given a registered user", output)
+        self.assertIn("... passed", output)
+        self.assertIn("... failed", output)
+        self.assertIn("Assertion Failed", output)
+
+    def test_undefined_scenario_produces_no_output(self):
+        formatter, stream = self._make_formatter()
+        feature = self._make_feature()
+        scenario = self._make_scenario()
+        step = self._make_step(status=Status.undefined)
+
+        formatter.feature(feature)
+        formatter.scenario(scenario)
+        formatter.step(step)
+        formatter.result(step)
+        formatter.eof()
+        formatter.close()
+
+        self.assertEqual(stream.getvalue(), "")
+
+    def test_skipped_scenario_produces_no_output(self):
+        formatter, stream = self._make_formatter()
+        feature = self._make_feature()
+        scenario = self._make_scenario()
+        step = self._make_step(status=Status.skipped)
+
+        formatter.feature(feature)
+        formatter.scenario(scenario)
+        formatter.step(step)
+        formatter.result(step)
+        formatter.eof()
+        formatter.close()
+
+        self.assertEqual(stream.getvalue(), "")
+```
+
+- [ ] **Step 6: Run all tests to verify they pass**
+
+Run: `python -m pytest tests/unit/test_formatter_fail_focus.py -v`
+Expected: All 4 tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add behave/formatter/fail_focus.py tests/unit/test_formatter_fail_focus.py
+git commit -m "feat: add FailFocusFormatter for --fail-focus mode"
+```
+
+---
+
+### Task 2: Register fail_focus formatter
+
+**Files:**
+- Modify: `behave/formatter/_builtins.py:12-34`
+
+- [ ] **Step 1: Write a test that the formatter is registered**
+
+Add to `tests/unit/test_formatter_fail_focus.py`:
+
+```python
+class TestFailFocusFormatterRegistration(unittest.TestCase):
+    def test_fail_focus_formatter_is_registered(self):
+        from behave.formatter._registry import is_formatter_valid
+        from behave.formatter._builtins import setup_formatters
+        setup_formatters()
+        self.assertTrue(is_formatter_valid("fail_focus"))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/unit/test_formatter_fail_focus.py::TestFailFocusFormatterRegistration -v`
+Expected: FAIL — `fail_focus` not found in registry
+
+- [ ] **Step 3: Add fail_focus to _builtins.py**
+
+In `behave/formatter/_builtins.py`, add to `_BUILTIN_FORMATS` list (after the `"captured"` entry):
+
+```python
+    ("fail_focus", "behave.formatter.fail_focus:FailFocusFormatter"),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/unit/test_formatter_fail_focus.py::TestFailFocusFormatterRegistration -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add behave/formatter/_builtins.py tests/unit/test_formatter_fail_focus.py
+git commit -m "feat: register fail_focus formatter in builtins"
+```
+
+---
+
+### Task 3: Add --fail-focus CLI parameter and setup_fail_focus_mode
+
+**Files:**
+- Modify: `behave/configuration.py:407-431` (OPTIONS list, add after `--wip`)
+- Modify: `behave/configuration.py:826-827` (add setup call after wip setup)
+- Modify: `behave/configuration.py:874` (init method, add `fail_focus = None`)
+- Modify: `behave/configuration.py:950-969` (add `setup_fail_focus_mode` method after `setup_wip_mode`)
+
+- [ ] **Step 1: Write a test for Configuration with --fail-focus**
+
+Add to `tests/unit/test_formatter_fail_focus.py`:
+
+```python
+class TestFailFocusConfiguration(unittest.TestCase):
+    def test_fail_focus_sets_stop_and_no_snippets(self):
+        from behave.configuration import Configuration
+        config = Configuration(command_args=["--fail-focus", "features/"],
+                               load_config=False)
+        self.assertTrue(config.stop)
+        self.assertFalse(config.show_snippets)
+
+    def test_fail_focus_sets_formatter_to_fail_focus(self):
+        from behave.configuration import Configuration
+        config = Configuration(command_args=["--fail-focus", "features/"],
+                               load_config=False)
+        self.assertIn("fail_focus", config.format)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/unit/test_formatter_fail_focus.py::TestFailFocusConfiguration -v`
+Expected: FAIL — `--fail-focus` not recognized
+
+- [ ] **Step 3: Add --fail-focus option to OPTIONS list**
+
+In `behave/configuration.py`, add after the `--wip` option block (after line 411):
+
+```python
+    (("--fail-focus",),
+     dict(action="store_true",
+          help="""Focus on the first failure only. Additionally: use the
+                  "fail_focus" formatter, stop at the first failure,
+                  and do not show snippets for undefined steps.""")),
+```
+
+- [ ] **Step 4: Add fail_focus to init() method**
+
+In `behave/configuration.py`, in the `init()` method, add after `self.wip = None` (line 874):
+
+```python
+        self.fail_focus = None
+```
+
+- [ ] **Step 5: Add setup_fail_focus_mode() method**
+
+In `behave/configuration.py`, add after `setup_wip_mode()` method (after line 969):
+
+```python
+    def setup_fail_focus_mode(self):
+        # Focus on first failure only.
+        # Additionally:
+        #  * use the "fail_focus" formatter (per default)
+        #  * stop at the first failure
+        #  * do not show snippets for undefined steps
+        self.default_format = "fail_focus"
+        self.stop = True
+        self.show_snippets = False
+```
+
+- [ ] **Step 6: Call setup_fail_focus_mode() in __init__**
+
+In `behave/configuration.py`, add after `if self.wip: self.setup_wip_mode()` (after line 827):
+
+```python
+        if self.fail_focus:
+            self.setup_fail_focus_mode()
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `python -m pytest tests/unit/test_formatter_fail_focus.py::TestFailFocusConfiguration -v`
+Expected: PASS
+
+- [ ] **Step 8: Run all fail_focus tests**
+
+Run: `python -m pytest tests/unit/test_formatter_fail_focus.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add behave/configuration.py tests/unit/test_formatter_fail_focus.py
+git commit -m "feat: add --fail-focus CLI parameter"
+```
+
+---
+
+### Task 4: Integration verification
+
+**Files:**
+- No new files
+
+- [ ] **Step 1: Run the full behave test suite to check for regressions**
+
+Run: `python -m pytest tests/unit/ -v`
+Expected: All existing tests PASS
+
+- [ ] **Step 2: Verify --fail-focus appears in help**
+
+Run: `python -m behave --help | grep -A3 fail-focus`
+Expected: Shows the `--fail-focus` option with its help text
+
+- [ ] **Step 3: Test manually with a real feature file (if available)**
+
+Run: `python -m behave --fail-focus` (in a directory with feature files)
+Expected: Only the first failure is shown with Feature header, scenario, steps, and error
+
+- [ ] **Step 4: Commit any fixes if needed**
+
+```bash
+git add -u
+git commit -m "fix: address integration issues for --fail-focus"
+```

--- a/docs/superpowers/specs/2026-04-01-fail-focus-design.md
+++ b/docs/superpowers/specs/2026-04-01-fail-focus-design.md
@@ -1,0 +1,64 @@
+# Design: `--fail-focus` Parameter
+
+## Overview
+
+Add a `--fail-focus` CLI parameter to behave that focuses output on the first failing scenario only, suppressing passed scenarios, undefined step snippets, and other noise.
+
+## Behavior
+
+When `behave --fail-focus` is invoked:
+
+1. **Auto-enable `--stop`** — stop execution on first failure
+2. **Auto-enable `--no-snippets`** — suppress undefined step snippet suggestions
+3. **Use `fail_focus` formatter** — replaces the default formatter to control output
+
+## Formatter Output Rules
+
+- **Passed scenarios**: completely silent
+- **Undefined/skipped scenarios**: completely silent
+- **Feature header**: deferred output — only printed when a scenario under that feature fails. Includes feature name + file path.
+- **Failed scenario**: outputs:
+  - Feature name and file path
+  - Scenario name and line number
+  - All steps with pass/fail status markers
+  - Failed step's error message and traceback
+
+## Output Example
+
+```
+Feature: User login -- features/login.feature
+
+  Scenario: Login with wrong password  -- features/login.feature:15
+    Given a registered user "alice"  ... passed
+    When she logs in with password "wrong"  ... passed
+    Then she should see an error message  ... failed
+      Assertion Failed: Expected error message not found
+      Traceback (most recent call last):
+        File "features/steps/login_steps.py", line 42, in step_impl
+          assert context.error_message is not None
+      AssertionError
+```
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `behave/formatter/fail_focus.py` | **New** — FailFocusFormatter class |
+| `behave/formatter/_registry.py` | Register `fail_focus` formatter |
+| `behave/configuration.py` | Add `--fail-focus` argument definition |
+| `behave/runner.py` | Handle `--fail-focus` logic (set stop, no-snippets, override formatter) |
+
+## FailFocusFormatter Design
+
+- Extends `Formatter` base class from `behave/formatter/base.py`
+- Tracks current feature (deferred output)
+- On `scenario()`: stores current scenario
+- On `result()`: tracks step results for current scenario
+- On scenario end: if scenario failed, flush feature header (if not yet printed) + scenario + steps with error details
+- On scenario end: if scenario passed/undefined/skipped, discard buffered output
+
+## Compatibility
+
+- Works with `--tags`, `--include`, `--exclude` and other filtering parameters
+- If `--format` is also specified, `--fail-focus` formatter takes precedence (with a warning)
+- Does not affect JUnit XML or other file-based reporters

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -245,6 +245,7 @@ class TestConfigFileParser:
             "default_tags",
             "dry_run",
             "exclude_re",
+            "fail_focus",
             "format",
             "include_re",
             "jobs",

--- a/tests/unit/test_formatter_fail_focus.py
+++ b/tests/unit/test_formatter_fail_focus.py
@@ -257,5 +257,20 @@ class TestFailFocusFormatterRegistration(unittest.TestCase):
         self.assertTrue(is_formatter_valid("fail_focus"))
 
 
+class TestFailFocusConfiguration(unittest.TestCase):
+    def test_fail_focus_sets_stop_and_no_snippets(self):
+        from behave.configuration import Configuration
+        config = Configuration(command_args=["--fail-focus", "features/"],
+                               load_config=False)
+        self.assertTrue(config.stop)
+        self.assertFalse(config.show_snippets)
+
+    def test_fail_focus_sets_formatter_to_fail_focus(self):
+        from behave.configuration import Configuration
+        config = Configuration(command_args=["--fail-focus", "features/"],
+                               load_config=False)
+        self.assertIn("fail_focus", config.format)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_formatter_fail_focus.py
+++ b/tests/unit/test_formatter_fail_focus.py
@@ -206,9 +206,9 @@ class TestFailFocusFormatterFeatureDeduplication(unittest.TestCase):
 
 
 class TestFailFocusFormatterUndefinedScenario(unittest.TestCase):
-    """An undefined scenario is treated as an error and should produce output."""
+    """An undefined scenario should produce no output (suppressed by --fail-focus)."""
 
-    def test_undefined_scenario_produces_output(self):
+    def test_undefined_scenario_produces_no_output(self):
         stream = io.StringIO()
         formatter = make_formatter(stream)
 
@@ -223,9 +223,7 @@ class TestFailFocusFormatterUndefinedScenario(unittest.TestCase):
         formatter.eof()
         formatter.close()
 
-        output = stream.getvalue()
-        self.assertIn("Scenario: Test Scenario", output)
-        self.assertIn("Given an undefined step ... undefined", output)
+        self.assertEqual(stream.getvalue(), "")
 
 
 class TestFailFocusFormatterSkippedScenario(unittest.TestCase):

--- a/tests/unit/test_formatter_fail_focus.py
+++ b/tests/unit/test_formatter_fail_focus.py
@@ -247,5 +247,15 @@ class TestFailFocusFormatterSkippedScenario(unittest.TestCase):
         self.assertEqual(stream.getvalue(), "")
 
 
+class TestFailFocusFormatterRegistration(unittest.TestCase):
+    """The fail_focus formatter should be registered in the builtins."""
+
+    def test_fail_focus_formatter_is_registered(self):
+        from behave.formatter._registry import is_formatter_valid
+        from behave.formatter._builtins import setup_formatters
+        setup_formatters()
+        self.assertTrue(is_formatter_valid("fail_focus"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_formatter_fail_focus.py
+++ b/tests/unit/test_formatter_fail_focus.py
@@ -92,11 +92,123 @@ class TestFailFocusFormatterFailedScenario(unittest.TestCase):
         self.assertIn("When they enter wrong password ... failed", output)
         self.assertIn("AssertionError: expected 200 got 401", output)
 
+    def test_failed_scenario_exact_output_format(self):
+        stream = io.StringIO()
+        formatter = make_formatter(stream)
+
+        feature = make_feature("Login", "features/login.feature")
+        scenario = make_scenario("Bad password", "features/login.feature", 5)
+        step1 = make_step("Given", "a user exists", Status.passed)
+        step2 = make_step("When", "they enter wrong password", Status.failed,
+                          "AssertionError: expected 200 got 401")
+
+        formatter.feature(feature)
+        formatter.scenario(scenario)
+        formatter.step(step1)
+        formatter.result(step1)
+        formatter.step(step2)
+        formatter.result(step2)
+        formatter.eof()
+        formatter.close()
+
+        expected = (
+            "Feature: Login -- features/login.feature\n"
+            "\n"
+            "  Scenario: Bad password  -- features/login.feature:5\n"
+            "    Given a user exists ... passed\n"
+            "    When they enter wrong password ... failed\n"
+            "AssertionError: expected 200 got 401\n"
+        )
+        self.assertEqual(stream.getvalue(), expected)
+
+
+class TestFailFocusFormatterErrorScenario(unittest.TestCase):
+    """A scenario with a Status.error step should produce output."""
+
+    def test_error_scenario_produces_output(self):
+        stream = io.StringIO()
+        formatter = make_formatter(stream)
+
+        feature = make_feature("Login", "features/login.feature")
+        scenario = make_scenario("Crash on login", "features/login.feature", 20)
+        step1 = make_step("Given", "a user exists", Status.passed)
+        step2 = make_step("When", "the server crashes", Status.error,
+                          "RuntimeError: unexpected failure")
+
+        formatter.feature(feature)
+        formatter.scenario(scenario)
+        formatter.step(step1)
+        formatter.result(step1)
+        formatter.step(step2)
+        formatter.result(step2)
+        formatter.eof()
+        formatter.close()
+
+        output = stream.getvalue()
+        self.assertIn("Feature: Login -- features/login.feature", output)
+        self.assertIn("Scenario: Crash on login", output)
+        self.assertIn("When the server crashes ... error", output)
+        self.assertIn("RuntimeError: unexpected failure", output)
+
+    def test_hook_error_scenario_produces_output(self):
+        stream = io.StringIO()
+        formatter = make_formatter(stream)
+
+        feature = make_feature("Login", "features/login.feature")
+        scenario = make_scenario("Hook failure", "features/login.feature", 30)
+        step1 = make_step("Given", "a step", Status.hook_error,
+                          "HookError: before_scenario failed")
+
+        formatter.feature(feature)
+        formatter.scenario(scenario)
+        formatter.step(step1)
+        formatter.result(step1)
+        formatter.eof()
+        formatter.close()
+
+        output = stream.getvalue()
+        self.assertIn("Scenario: Hook failure", output)
+        self.assertIn("HookError: before_scenario failed", output)
+
+
+class TestFailFocusFormatterFeatureDeduplication(unittest.TestCase):
+    """Feature header should only be printed once per feature."""
+
+    def test_feature_header_printed_once_for_multiple_failures(self):
+        stream = io.StringIO()
+        formatter = make_formatter(stream)
+
+        feature = make_feature("Login", "features/login.feature")
+        scenario1 = make_scenario("Fail 1", "features/login.feature", 5)
+        scenario2 = make_scenario("Fail 2", "features/login.feature", 15)
+        step1 = make_step("Given", "a failing step", Status.failed, "Error 1")
+        step2 = make_step("Given", "another failing step", Status.failed, "Error 2")
+
+        formatter.feature(feature)
+
+        formatter.scenario(scenario1)
+        formatter.step(step1)
+        formatter.result(step1)
+
+        formatter.scenario(scenario2)
+        formatter.step(step2)
+        formatter.result(step2)
+
+        formatter.eof()
+        formatter.close()
+
+        output = stream.getvalue()
+        # Feature header should appear exactly once
+        self.assertEqual(output.count("Feature: Login -- features/login.feature"), 1)
+        # Both scenarios should appear
+        self.assertIn("Scenario: Fail 1", output)
+        self.assertIn("Scenario: Fail 2", output)
+
 
 class TestFailFocusFormatterUndefinedScenario(unittest.TestCase):
-    """An undefined scenario should produce no output."""
+    """An undefined scenario is treated as an error and should produce output."""
 
-    def test_undefined_scenario_produces_no_output(self):
+    def test_undefined_scenario_produces_output(self):
         stream = io.StringIO()
         formatter = make_formatter(stream)
 
@@ -111,7 +223,9 @@ class TestFailFocusFormatterUndefinedScenario(unittest.TestCase):
         formatter.eof()
         formatter.close()
 
-        self.assertEqual(stream.getvalue(), "")
+        output = stream.getvalue()
+        self.assertIn("Scenario: Test Scenario", output)
+        self.assertIn("Given an undefined step ... undefined", output)
 
 
 class TestFailFocusFormatterSkippedScenario(unittest.TestCase):

--- a/tests/unit/test_formatter_fail_focus.py
+++ b/tests/unit/test_formatter_fail_focus.py
@@ -1,0 +1,139 @@
+"""Unit tests for the FailFocusFormatter."""
+
+import io
+import unittest
+from unittest.mock import Mock
+
+from behave.formatter.base import StreamOpener
+from behave.model_type import Status
+
+
+def make_feature(name="Test Feature", filename="features/test.feature"):
+    feature = Mock()
+    feature.name = name
+    feature.filename = filename
+    feature.keyword = "Feature"
+    return feature
+
+
+def make_scenario(name="Test Scenario", filename="features/test.feature", line=10):
+    scenario = Mock()
+    scenario.name = name
+    scenario.keyword = "Scenario"
+    scenario.location = Mock()
+    scenario.location.filename = filename
+    scenario.location.line = line
+    return scenario
+
+
+def make_step(keyword="Given", name="a step", status=Status.passed, error_message=None):
+    step = Mock()
+    step.keyword = keyword
+    step.name = name
+    step.status = status
+    step.error_message = error_message
+    return step
+
+
+def make_formatter(stream):
+    from behave.formatter.fail_focus import FailFocusFormatter
+    config = Mock()
+    stream_opener = StreamOpener(stream=stream)
+    return FailFocusFormatter(stream_opener, config)
+
+
+class TestFailFocusFormatterPassedScenario(unittest.TestCase):
+    """A passed scenario should produce no output."""
+
+    def test_passed_scenario_produces_no_output(self):
+        stream = io.StringIO()
+        formatter = make_formatter(stream)
+
+        feature = make_feature()
+        scenario = make_scenario()
+        step1 = make_step("Given", "a passing step", Status.passed)
+
+        formatter.feature(feature)
+        formatter.scenario(scenario)
+        formatter.step(step1)
+        formatter.result(step1)
+        formatter.eof()
+        formatter.close()
+
+        self.assertEqual(stream.getvalue(), "")
+
+
+class TestFailFocusFormatterFailedScenario(unittest.TestCase):
+    """A failed scenario should produce output with feature, scenario, steps, and error."""
+
+    def test_failed_scenario_produces_output(self):
+        stream = io.StringIO()
+        formatter = make_formatter(stream)
+
+        feature = make_feature("Login", "features/login.feature")
+        scenario = make_scenario("Bad password", "features/login.feature", 5)
+        step1 = make_step("Given", "a user exists", Status.passed)
+        step2 = make_step("When", "they enter wrong password", Status.failed,
+                          "AssertionError: expected 200 got 401")
+
+        formatter.feature(feature)
+        formatter.scenario(scenario)
+        formatter.step(step1)
+        formatter.result(step1)
+        formatter.step(step2)
+        formatter.result(step2)
+        formatter.eof()
+        formatter.close()
+
+        output = stream.getvalue()
+        self.assertIn("Feature: Login -- features/login.feature", output)
+        self.assertIn("Scenario: Bad password  -- features/login.feature:5", output)
+        self.assertIn("Given a user exists ... passed", output)
+        self.assertIn("When they enter wrong password ... failed", output)
+        self.assertIn("AssertionError: expected 200 got 401", output)
+
+
+class TestFailFocusFormatterUndefinedScenario(unittest.TestCase):
+    """An undefined scenario should produce no output."""
+
+    def test_undefined_scenario_produces_no_output(self):
+        stream = io.StringIO()
+        formatter = make_formatter(stream)
+
+        feature = make_feature()
+        scenario = make_scenario()
+        step1 = make_step("Given", "an undefined step", Status.undefined)
+
+        formatter.feature(feature)
+        formatter.scenario(scenario)
+        formatter.step(step1)
+        formatter.result(step1)
+        formatter.eof()
+        formatter.close()
+
+        self.assertEqual(stream.getvalue(), "")
+
+
+class TestFailFocusFormatterSkippedScenario(unittest.TestCase):
+    """A skipped scenario should produce no output."""
+
+    def test_skipped_scenario_produces_no_output(self):
+        stream = io.StringIO()
+        formatter = make_formatter(stream)
+
+        feature = make_feature()
+        scenario = make_scenario()
+        step1 = make_step("Given", "a skipped step", Status.skipped)
+
+        formatter.feature(feature)
+        formatter.scenario(scenario)
+        formatter.step(step1)
+        formatter.result(step1)
+        formatter.eof()
+        formatter.close()
+
+        self.assertEqual(stream.getvalue(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_formatter_fail_focus.py
+++ b/tests/unit/test_formatter_fail_focus.py
@@ -258,12 +258,13 @@ class TestFailFocusFormatterRegistration(unittest.TestCase):
 
 
 class TestFailFocusConfiguration(unittest.TestCase):
-    def test_fail_focus_sets_stop_and_no_snippets(self):
+    def test_fail_focus_sets_stop_and_no_snippets_and_no_summary(self):
         from behave.configuration import Configuration
         config = Configuration(command_args=["--fail-focus", "features/"],
                                load_config=False)
         self.assertTrue(config.stop)
         self.assertFalse(config.show_snippets)
+        self.assertFalse(config.summary)
 
     def test_fail_focus_sets_formatter_to_fail_focus(self):
         from behave.configuration import Configuration


### PR DESCRIPTION
## Summary

- Add `--fail-focus` CLI parameter that focuses output on the first failing scenario only
- When enabled, automatically sets `--stop`, `--no-snippets`, and `--no-summary`
- New `FailFocusFormatter` that suppresses passed/undefined/skipped scenarios and only outputs failing scenarios with Feature header, step details, and error traceback

### Example

```bash
$ behave --fail-focus
Feature: User login -- features/login.feature

  Scenario: Login with wrong password  -- features/login.feature:8
    Given a registered user "alice" ... passed
    When she logs in with password "wrong" ... passed
    Then she should see an error message ... failed
ASSERT FAILED: Expected error message not found
```

### Files changed

| File | Change |
|------|--------|
| `behave/formatter/fail_focus.py` | New `FailFocusFormatter` class |
| `behave/formatter/_builtins.py` | Register `fail_focus` in formatter registry |
| `behave/configuration.py` | Add `--fail-focus` option + `setup_fail_focus_mode()` |
| `tests/unit/test_formatter_fail_focus.py` | 11 unit tests |
| `tests/unit/test_configuration.py` | Add `fail_focus` to config options name list |

## Test plan

- [x] 11 unit tests covering: passed (silent), failed (output), error/hook_error (output), undefined (silent), skipped (silent), feature header dedup, formatter registration, CLI config
- [x] Full unit test suite (1382 tests) passes with zero regressions
- [x] Manual testing with real feature files confirms expected behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)