### PR TITLE
chore: drop six dependency and replace with native python 3 equivalents

### DIFF
--- a/behave/model_type.py
+++ b/behave/model_type.py
@@ -5,7 +5,6 @@ Basic types that are used in the model classes.
 from enum import Enum
 import os.path
 import sys
-import six
 from behave._types import require_type
 from behave.textutil import text as _text
 
@@ -386,7 +385,7 @@ class FileLocation:
         :return: FileLocation object
         """
         func = unwrap_function(func)
-        function_code = six.get_function_code(func)
+        function_code = func.__code__
         filename = function_code.co_filename
         line_number = function_code.co_firstlineno
 

--- a/behave/runner.py
+++ b/behave/runner.py
@@ -9,8 +9,6 @@ import traceback
 import warnings
 import weakref
 
-import six
-
 from behave._types import (
     require_type,
     require_not_type,
@@ -280,14 +278,12 @@ class Context:
             except Exception as e: # pylint: disable=broad-except
                 # pylint: disable=protected-access
                 context._root["cleanup_errors"] += 1
-                cleanup_errors.append(sys.exc_info())
+                cleanup_errors.append(e)
                 on_cleanup_error(context, cleanup_func, e)
 
         current_layer["@cleanups"] = []
         if self.fail_on_cleanup_errors and cleanup_errors:
-            first_cleanup_erro_info = cleanup_errors[0]
-            del cleanup_errors  # -- ENSURE: Release other exception frames.
-            six.reraise(*first_cleanup_erro_info)
+            raise cleanup_errors[0]
 
     def _do_remaining_cleanups(self, capture_sink=None):
         """
@@ -302,15 +298,13 @@ class Context:
             try:
                 # -- PERFORM CLEANUPS:
                 self._pop(capture_sink=capture_sink)
-            except Exception:
-                cleanup_errors.append(sys.exc_info())
+            except Exception as e:
+                cleanup_errors.append(e)
 
         # -- FINALLY: Perform cleanups on last layer (if needed).
         self._do_cleanups()
         if self.fail_on_cleanup_errors and cleanup_errors:
-            first_cleanup_erro_info = cleanup_errors[0]
-            del cleanup_errors  # -- ENSURE: Release other exception frames.
-            six.reraise(*first_cleanup_erro_info)
+            raise cleanup_errors[0]
 
     def _push(self, layer=None):
         """Push a new layer on the context stack.

--- a/py.requirements/basic.txt
+++ b/py.requirements/basic.txt
@@ -23,6 +23,3 @@ tomli>=1.1.0; python_version >=  '3.0' and python_version < '3.11'
 # -- PREPARED: charset-normalizer:
 # SEE: https://pypi.org/project/charset-normalizer/
 charset-normalizer >= 3.1; python_version >= '3.8'
-
-# -- XXX_JE_CLEANUP_CANDIDATE:
-six >= 1.15.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,8 +86,6 @@ dependencies = [
     "cucumber-expressions >= 17.1.0; python_version >= '3.8'",
     "parse >= 1.18.0",
     "parse-type >= 0.6.0",
-    # -- XXX_JE_CLEANUP_CANDIDATE:
-    "six >= 1.15.0",
 
     # -- DISABLED: "win_unicode_console; python_version <= '3.9'",
     "colorama >= 0.3.7",

--- a/tests/unit/test_context_cleanups.py
+++ b/tests/unit/test_context_cleanups.py
@@ -13,7 +13,7 @@ from behave.configuration import Configuration
 from behave.runner import Context, Runner, scoped_context_layer
 from unittest.mock import Mock
 import pytest
-
+import traceback
 
 # ------------------------------------------------------------------------------
 # TEST SUPPORT:
@@ -212,6 +212,36 @@ class TestContextCleanup:
         # expected_args = (context, handle_cleanup_error_func,
         #                 RuntimeError("in CLEANUP call"))
         # handle_cleanup_error_func.assert_called_with(*expected_args)
+
+    def test_cleanup_error_raised_preserves_cleanup_traceback_frame(self):
+        class CleanupError(RuntimeError):
+            def __init__(self):
+                super().__init__("detailed-info")
+
+        def bad_cleanup():
+            raise CleanupError()
+
+        context = make_context()
+        with pytest.raises(RuntimeError) as e:
+            with scoped_context_layer(context):
+                context.add_cleanup(bad_cleanup)
+
+        # -- ENSURE: The traceback frames are preserved, including the bad_cleanup frame
+        actual = [frame.name for frame in traceback.extract_tb(e.tb)]
+        wanted = [
+            "__exit__",
+            "scoped_context_layer",
+            "_pop",
+            "_do_cleanups",
+            "_do_cleanups",
+            "bad_cleanup",
+        ]
+
+        # -- ENSURE: The custom CleanupError is preserved as the exception type and message
+        # NOTE: The outermost frame is the test function, which may vary, so we skip it in the assertion.
+        assert actual[1:] == wanted
+        assert isinstance(e.value, CleanupError)
+        assert str(e.value) == CleanupError().args[0]
 
     def test_on_cleanup_error__may_be_called_several_times_per_cleanup(self):
         def bad_cleanup1():


### PR DESCRIPTION
As shortly discussed in https://github.com/behave/behave/pull/1309, this PR slightly extends the six dependency removal.

Since support for Python 2.7 will be removed, the six Python 2/3 compatibility shim is no longer needed.

- `model_type.py`: use `func.__code__` instead of `six.get_function_code()`
- `runner.py`: store exception instances and raise them directly instead of `sys.exc_info()` + `six.reraise()`.
- `basic.txt`, `pyproject.toml`: remove six from deps