### PR TITLE
chore: drop colorama dependency

### DIFF
--- a/py.requirements/basic.txt
+++ b/py.requirements/basic.txt
@@ -14,9 +14,6 @@ cucumber-expressions >= 17.1.0; python_version >= '3.8'
 parse >= 1.18.0
 parse_type >= 0.6.0
 
-# DISABLED: win_unicode_console >= 0.5;  python_version < '3.6'
-colorama >= 0.3.7
-
 # -- SUPPORT: "pyproject.toml" (or: "behave.toml")
 tomli>=1.1.0; python_version >=  '3.0' and python_version < '3.11'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,9 +89,6 @@ dependencies = [
     # -- XXX_JE_CLEANUP_CANDIDATE:
     "six >= 1.15.0",
 
-    # -- DISABLED: "win_unicode_console; python_version <= '3.9'",
-    "colorama >= 0.3.7",
-
     # -- SUPPORT: "pyproject.toml" (or: "behave.toml")
     "tomli>=1.1.0; python_version >=  '3.0' and python_version < '3.11'",
 ]


### PR DESCRIPTION
Remove unused `colorama` dependency, as well as `win_unicode_console`, which is unused, too.