### PR TITLE
auto-promote raw bool values to BoolValueObject in ActiveTagMatcher

### DIFF
--- a/behave/tag_matcher.py
+++ b/behave/tag_matcher.py
@@ -51,6 +51,22 @@ class ValueObject:
         self._value = value
         self.compare = compare
 
+    @classmethod
+    def from_raw(cls, value):
+        """Wrap a raw provider value in the most appropriate ValueObject subclass.
+
+        Picks :class:`BoolValueObject` for ``bool`` values so that string tag
+        values like ``"true"`` / ``"false"`` are coerced before comparison —
+        otherwise ``operator.eq(True, "true")`` is always ``False`` and bool
+        active-tag matching silently never matches. See issue #1320.
+
+        Note: ``isinstance(value, bool)`` must be checked before any ``int``
+        check since ``bool`` is a subclass of ``int`` in Python.
+        """
+        if isinstance(value, bool):
+            return BoolValueObject(value)
+        return cls(value)
+
     @property
     def value(self):
         if callable(self._value):
@@ -446,7 +462,7 @@ class ActiveTagMatcher(TagMatcher):
             # -- CASE: Unknown category, ignore it.
             return True
         elif not isinstance(current_value, ValueObject):
-            current_value = ValueObject(current_value)
+            current_value = ValueObject.from_raw(current_value)
 
         positive_tags_matched = []
         negative_tags_matched = []

--- a/tests/issues/test_issue1320.py
+++ b/tests/issues/test_issue1320.py
@@ -1,0 +1,82 @@
+"""
+Regression tests for issue #1320:
+Auto-promote raw ``bool`` provider values to :class:`BoolValueObject`.
+
+Without auto-promotion, ``ActiveTagMatcher`` wraps a raw ``bool`` in the base
+``ValueObject``, which compares with ``operator.eq``. Tag values from a
+feature file are always strings, so ``operator.eq(True, "true")`` is ``False``
+and bool active-tag matching silently never matches.
+"""
+
+import pytest
+
+from behave.tag_matcher import (
+    ActiveTagMatcher,
+    BoolValueObject,
+    ValueObject,
+    setup_active_tag_values,
+)
+
+
+class TestIssue1320BoolAutoPromotion:
+    @pytest.mark.parametrize(
+        "provider_value, tag_value, expected_enabled",
+        [
+            (True, "true", True),
+            (True, "false", False),
+            (False, "true", False),
+            (False, "false", True),
+            # BoolValueObject.to_bool also accepts these spellings.
+            (True, "yes", True),
+            (True, "on", True),
+            (False, "no", True),
+            (False, "off", True),
+        ],
+    )
+    def test_use_with_bool_provider_value(
+        self, provider_value, tag_value, expected_enabled
+    ):
+        provider = {"flag": "undefined"}
+        matcher = ActiveTagMatcher(provider)
+        setup_active_tag_values(provider, {"flag": provider_value})
+
+        tag = matcher.make_category_tag("flag", tag_value)
+        # `should_skip_with_tags` is the inverse of "enabled".
+        assert matcher.should_skip_with_tags([tag]) is (not expected_enabled)
+
+    def test_explicit_bool_value_object_still_works(self):
+        """Users who already wrap in BoolValueObject must not regress."""
+        provider = {"flag": "undefined"}
+        matcher = ActiveTagMatcher(provider)
+        setup_active_tag_values(provider, {"flag": BoolValueObject(True)})
+
+        tag = matcher.make_category_tag("flag", "true")
+        assert matcher.should_skip_with_tags([tag]) is False
+
+    def test_string_provider_value_unchanged(self):
+        """Non-bool provider values still go through the plain ValueObject path."""
+        provider = {"name": "undefined"}
+        matcher = ActiveTagMatcher(provider)
+        setup_active_tag_values(provider, {"name": "alice"})
+
+        assert matcher.should_skip_with_tags([matcher.make_category_tag("name", "alice")]) is False
+        assert matcher.should_skip_with_tags([matcher.make_category_tag("name", "bob")]) is True
+
+
+class TestIssue1320ValueObjectFromRaw:
+    def test_from_raw_promotes_bool(self):
+        wrapped = ValueObject.from_raw(True)
+        assert type(wrapped) is BoolValueObject
+        assert wrapped.value is True
+
+    def test_from_raw_leaves_strings_alone(self):
+        wrapped = ValueObject.from_raw("alice")
+        assert type(wrapped) is ValueObject
+        assert wrapped.value == "alice"
+
+    def test_from_raw_does_not_promote_int(self):
+        # bool is a subclass of int -- make sure plain ints stay as ValueObject
+        # so we don't accidentally change number-handling semantics.
+        wrapped = ValueObject.from_raw(42)
+        assert type(wrapped) is ValueObject
+        assert wrapped.value == 42


### PR DESCRIPTION
- fixes https://github.com/behave/behave/issues/1320

See the issue above for motivation

This PR auto-promotes raw bool provider values to BoolValueObject at the wrap site, so `@use.with_<cat>=true` and `@use.with_<cat>=false` work as users expect when the provider value is a Python bool.

Also adds tests!

(Let me know if there's additional testing I can do to make sure this works well!)                        