### PR TITLE
fix(json): include captured stdout/stderr/log in JSON report (#1323)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,12 @@ FIXED:
 
 * Include changes from ``behave v1.3.1`` (#1255, #1239)
 * issue #1028: use unittest.mock instead of mock (submitted by: pgajdos)
+* issue #1323: JSON formatter: Captured output (stdout/stderr/log) is now
+  provided as dedicated ``result`` fields (``captured_stdout``,
+  ``captured_stderr``, ``captured_log``). Previously the captured logging was
+  embedded in the step ``error_message``; the capture refactoring (v1.2.7) moved
+  it to ``step.captured``, so it went missing from JSON reports of a failed step.
+  These new, structured fields restore that information.
 
 DOCUMENTATION:
 

--- a/behave/formatter/json.py
+++ b/behave/formatter/json.py
@@ -147,19 +147,58 @@ class JSONFormatter(Formatter):
             steps = self.current_feature_element["steps"]
             steps[self._step_index]["match"] = match_data
 
+    # -- CAPTURED OUTPUT: Streams provided as JSON "result" fields.
+    CAPTURED_OUTPUT_NAMES = ("stdout", "stderr", "log")
+
+    @classmethod
+    def _format_text(cls, text):
+        """Split multi-line text into a list of lines (for readability)."""
+        if cls.split_text_into_lines and "\n" in text:
+            return text.splitlines()
+        return text
+
+    @classmethod
+    def make_captured_output(cls, captured, exclude_text=None):
+        """Build the JSON "result" fields for the captured output of a step.
+
+        SINCE behave v1.2.7, captured output is stored on the model element
+        (in ``step.captured``) instead of being inlined into the step's
+        ``error_message``. This exposes it as dedicated JSON fields so that
+        JSON reports retain the captured stdout/stderr/log (esp. the
+        "Captured logging" of a failed step).
+
+        :param captured: Captured output (value object), see :class:`Captured`.
+        :param exclude_text:
+            Optional text to omit. For a failed step, the error message is also
+            stored in the captured stderr (see ``Step._process_error``); passing
+            ``step.error_message`` avoids duplicating it as ``captured_stderr``.
+        :return: Dict with ``captured_<name>`` fields (may be empty).
+
+        .. seealso:: https://github.com/behave/behave/issues/1323
+        """
+        captured_fields = {}
+        if not (captured and captured.has_output()):
+            return captured_fields
+        for name in cls.CAPTURED_OUTPUT_NAMES:
+            captured_text = getattr(captured, name, "")
+            if not captured_text or captured_text == exclude_text:
+                continue
+            captured_fields["captured_" + name] = cls._format_text(captured_text)
+        return captured_fields
+
     def result(self, step):
         steps = self.current_feature_element["steps"]
-        steps[self._step_index]["result"] = {
+        result_element = {
             "status": step.status.name,
             "duration": step.duration,
         }
+        steps[self._step_index]["result"] = result_element
         if step.error_message and step.status == Status.failed:
             # -- OPTIONAL: Provided for failed steps.
-            error_message = step.error_message
-            if self.split_text_into_lines and "\n" in error_message:
-                error_message = error_message.splitlines()
-            result_element = steps[self._step_index]["result"]
-            result_element["error_message"] = error_message
+            result_element["error_message"] = self._format_text(step.error_message)
+        result_element.update(
+            self.make_captured_output(step.captured, exclude_text=step.error_message)
+        )
         self._step_index += 1
 
     def embedding(self, mime_type, data):

--- a/behave/json_parser.py
+++ b/behave/json_parser.py
@@ -217,6 +217,14 @@ class JsonParser:
         step.status = Status.from_name(status_name)
         step.duration = duration
         step.error_message = error_message
+        # -- SINCE behave v1.2.7: Round-trip the captured output fields.
+        # RELATED: https://github.com/behave/behave/issues/1323
+        for name in ("stdout", "stderr", "log"):
+            captured_text = json_result.get("captured_" + name, None)
+            if isinstance(captured_text, list):
+                captured_text = "\n".join(captured_text)
+            if captured_text:
+                setattr(step.captured, name, captured_text)
 
     @staticmethod
     def parse_table(json_table):

--- a/issue.features/issue1323.feature
+++ b/issue.features/issue1323.feature
@@ -1,0 +1,55 @@
+@issue
+@logging
+@capture
+Feature: Issue #1323 -- JSON report missing captured logging on failure
+
+  Ensure the JSON formatter provides the captured output (stdout/stderr/log)
+  as first-class fields in the step "result". This way, JSON reports retain
+  the "Captured logging" of a failing scenario.
+
+  . REGRESSION: Since the capture refactoring (behave v1.2.7),
+  .   "JSONFormatter.result()" stopped including the captured logging that was
+  .   previously inlined into the "error_message" of a failed step.
+  .
+  . RELATED:
+  .  * features/formatter.json.feature
+  .  * features/capture_log.feature
+
+  Background:
+    Given a new working directory
+    And a file named "features/steps/use_behave4cmd_steps.py" with:
+        """
+        import behave4cmd0.log_steps
+        import behave4cmd0.failing_steps
+        import behave4cmd0.passing_steps
+        """
+    And a file named "features/environment.py" with:
+        """
+        def before_all(context):
+            context.config.setup_logging()
+        """
+    And a file named "features/log_and_fail.feature" with:
+        """
+        Feature:
+          Scenario: Failing with logs
+            Given I create log records with:
+                | category | level | message      |
+                | foo      | ERROR | Hello Bob    |
+                | bar      | WARN  | Hello Charly |
+            When another step fails
+        """
+
+  Scenario: Captured log is included in JSON report when a scenario fails
+    When I run "behave -f json.pretty -T --capture-log features/log_and_fail.feature"
+    Then it should fail with:
+        """
+        0 scenarios passed, 1 failed, 0 skipped
+        """
+    And the command output should contain:
+        """
+            "captured_log": [
+              "LOG_ERROR:foo: Hello Bob",
+              "LOG_WARNING:bar: Hello Charly"
+            ],
+        """
+    But the command output should not contain "captured_stderr"

--- a/tests/unit/formatter/test_json.py
+++ b/tests/unit/formatter/test_json.py
@@ -1,0 +1,60 @@
+"""
+Unit tests for :mod:`behave.formatter.json` module.
+
+Focus: :meth:`JSONFormatter.make_captured_output()` -- the captured
+stdout/stderr/log JSON fields (see issue #1323).
+"""
+
+from behave.capture import Captured, NO_CAPTURED_DATA
+from behave.formatter.json import JSONFormatter
+
+
+# -----------------------------------------------------------------------------
+# TEST SUITE
+# -----------------------------------------------------------------------------
+class TestMakeCapturedOutput:
+    """Unit tests for the (isolated) captured-output field builder."""
+
+    def test_without_output__returns_empty(self):
+        captured = Captured()
+        assert JSONFormatter.make_captured_output(captured) == {}
+
+    def test_with_no_captured_data__returns_empty(self):
+        assert JSONFormatter.make_captured_output(NO_CAPTURED_DATA) == {}
+
+    def test_with_none__returns_empty(self):
+        assert JSONFormatter.make_captured_output(None) == {}
+
+    def test_with_log_only(self):
+        captured = Captured(log="LOG_ERROR:foo: Hello")
+        captured_fields = JSONFormatter.make_captured_output(captured)
+        assert captured_fields == {"captured_log": "LOG_ERROR:foo: Hello"}
+
+    def test_with_all_streams(self):
+        captured = Captured(stdout="OUT", stderr="ERR", log="LOG")
+        captured_fields = JSONFormatter.make_captured_output(captured)
+        assert captured_fields == {
+            "captured_stdout": "OUT",
+            "captured_stderr": "ERR",
+            "captured_log": "LOG",
+        }
+
+    def test_multiline_text_is_split_into_lines(self):
+        captured = Captured(log="line1\nline2")
+        captured_fields = JSONFormatter.make_captured_output(captured)
+        assert captured_fields == {"captured_log": ["line1", "line2"]}
+
+    def test_exclude_text__omits_duplicated_stderr(self):
+        # -- DUPLICATION: A failed step stores its error_message in captured stderr.
+        error_message = "ASSERT FAILED: EXPECT something"
+        captured = Captured(stderr=error_message, log="LOG", failed=True)
+        captured_fields = JSONFormatter.make_captured_output(
+            captured, exclude_text=error_message)
+        assert "captured_stderr" not in captured_fields
+        assert captured_fields == {"captured_log": "LOG"}
+
+    def test_exclude_text__keeps_distinct_stderr(self):
+        captured = Captured(stderr="real stderr output")
+        captured_fields = JSONFormatter.make_captured_output(
+            captured, exclude_text="a different error message")
+        assert captured_fields == {"captured_stderr": "real stderr output"}


### PR DESCRIPTION
Fixes #1323.

## Problem

Before the capture refactoring (behave v1.2.7), the captured logging of a failed
step was embedded **inside the `error_message` string**, so it showed up in JSON
reports. The refactoring (`f4d5028`) moved captured output onto `step.captured`
and updated the `plain`/`pretty`/`progress` formatters — but `JSONFormatter.result()`
was never touched. As a result, `error_message` no longer contains the captured
logging and JSON reports silently lost it.

> Note: there were never dedicated `captured_*` fields in behave's JSON before —
> the data used to live inside `error_message`. This PR restores the information
> in a **structured** form rather than re-inlining it.

Thanks @bittner for the diagnosis and the suggested direction (expose captured
streams as first-class JSON fields).

## Change

- **`behave/formatter/json.py`**: emit dedicated `result` fields —
  `captured_stdout`, `captured_stderr`, `captured_log` — only when present.
  - For a failed step the error message is also stored in the captured stderr
    (`Step._process_error`), so `captured_stderr` is omitted when it would only
    duplicate the already-provided `error_message`.
  - The field-building is extracted into `JSONFormatter.make_captured_output()`
    (a `classmethod`, like the existing `make_table`) so `result()` stays flat
    and the logic is unit-testable in isolation.
- **`behave/json_parser.py`**: round-trips the new fields back onto
  `step.captured`, keeping read/write symmetric.
- **`tests/unit/formatter/test_json.py`**: unit tests for `make_captured_output()`
  (empty/no-capture, single/all streams, line-splitting, stderr de-duplication).
- **`issue.features/issue1323.feature`**: end-to-end regression test.
- **`CHANGES.rst`**: changelog entry.

## Example (`json.pretty`, failing scenario with logs)

```json
"result": {
  "captured_log": [
    "LOG_ERROR:foo: Hello Bob",
    "LOG_WARNING:bar: Hello Charly"
  ],
  "duration": 0.0003,
  "status": "passed"
}
```

## Verification

- `pytest`: JSON / parser / formatter tests pass (347 selected, incl. 8 new).
- behave self-tests pass: `features/formatter.json.feature`,
  `features/capture_log.feature`, and the new `issue.features/issue1323.feature`.
- `ruff` clean.

## Relation to #1326

Supersedes the approach in #1326 by additionally providing the parser round-trip,
unit + regression tests, the `captured_stderr`/`error_message` de-duplication,
and a changelog entry.

cc @jenisys (author of the capture refactoring — happy to adjust the field
naming/shape if you'd prefer something different) @c92s
