### PR TITLE
fix: add @functools.wraps to log_capture.capture decorator (#1329)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ FIXED:
 
 * Include changes from ``behave v1.3.1`` (#1255, #1239)
 * issue #1028: use unittest.mock instead of mock (submitted by: pgajdos)
+* issue #1329: add @functools.wraps to log_capture.capture decorator
 
 DOCUMENTATION:
 

--- a/behave/log_capture.py
+++ b/behave/log_capture.py
@@ -238,6 +238,7 @@ def capture(*args, **kw):
     """
     show_on_success = kw.pop("show_on_success", capture.show_on_success)
     def create_decorator(func, level=None):
+        @functools.wraps(func)
         def f(context, *args):
             h = LoggingCapture(context.config, level=level)
             h.inveigle()

--- a/issue.features/issue1329.feature
+++ b/issue.features/issue1329.feature
@@ -1,0 +1,37 @@
+@issue
+Feature: Issue #1329 -- @functools.wraps on log_capture.capture
+
+  . DESCRIPTION:
+  .   The @capture decorator in log_capture.py was missing @functools.wraps(func)
+  .   on its inner wrapper function, causing the original function name
+  .   (e.g., before_scenario) to be lost.
+  .
+  . SEE ALSO:
+  .   * https://github.com/behave/behave/issues/1329
+
+  Scenario: @capture preserves the decorated function name
+    Given a new working directory
+    And a file named "features/steps/use_steplib_behave4cmd.py" with:
+      """
+      import behave4cmd0.passing_steps
+      """
+    And a file named "features/environment.py" with:
+      """
+      from behave.log_capture import capture
+
+      @capture
+      def before_scenario(context, scenario):
+          pass
+      """
+    And a file named "features/issue1329.feature" with:
+      """
+      Feature: Issue 1329
+        Scenario: Check function name is preserved
+          Given a step passes
+      """
+    When I run "behave features/issue1329.feature"
+    Then it should pass with:
+      """
+      1 scenario passed, 0 failed, 0 skipped
+      1 step passed, 0 failed, 0 skipped
+      """

--- a/issue.features/issue1329.feature
+++ b/issue.features/issue1329.feature
@@ -19,6 +19,12 @@ Feature: Issue #1329 -- @functools.wraps on log_capture.capture
       """
       from behave.log_capture import capture
 
+      def assert_name_preserved(func):
+          assert func.__name__ == "before_scenario", \
+              "Expected __name__ == 'before_scenario', got: %r" % func.__name__
+          return func
+
+      @assert_name_preserved
       @capture
       def before_scenario(context, scenario):
           pass

--- a/tests/unit/test_log_capture.py
+++ b/tests/unit/test_log_capture.py
@@ -1,8 +1,23 @@
+import logging
 from unittest.mock import patch
-from behave.log_capture import LoggingCapture
+from behave.log_capture import LoggingCapture, capture
 
 
 class TestLogCapture:
+    def test_capture_preserves_function_name(self):
+        @capture
+        def before_scenario(context, scenario):
+            pass
+
+        assert before_scenario.__name__ == "before_scenario"
+
+    def test_capture_with_kwargs_preserves_function_name(self):
+        @capture(level=logging.ERROR)
+        def after_scenario(context, scenario):
+            pass
+
+        assert after_scenario.__name__ == "after_scenario"
+
     def test_get_value_returns_all_log_records(self):
         class FakeConfig:
             logging_filter = None


### PR DESCRIPTION
## Summary

Fixes #1329.

The `@capture` decorator in `behave/log_capture.py` was missing `@functools.wraps(func)` on its inner wrapper function `f`. This caused the original function name (e.g., `before_scenario`) to be lost, preventing outer decorators from inspecting the wrapped function name.

## Changes

- **`behave/log_capture.py`**: Added `@functools.wraps(func)` to the inner wrapper function inside `create_decorator`.
- **`tests/unit/test_log_capture.py`**: Added unit tests verifying that `@capture` preserves the decorated function's `__name__` (both bare `@capture` and `@capture(level=...)` forms).
- **`issue.features/issue1329.feature`**: End-to-end regression test.
- **`CHANGES.rst`**: Changelog entry under FIXED.

## Verification

```bash
python -m pytest tests/unit/test_log_capture.py -v -o addopts=""
```

All 3 tests pass.