### PR TITLE
fix: send USING RUNNER diagnostic to stderr (#1319)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ FIXED:
 
 * Include changes from ``behave v1.3.1`` (#1255, #1239)
 * issue #1028: use unittest.mock instead of mock (submitted by: pgajdos)
+* issue #1319: send "USING RUNNER" diagnostic message to stderr instead of stdout
 
 DOCUMENTATION:
 

--- a/behave/__main__.py
+++ b/behave/__main__.py
@@ -115,7 +115,8 @@ def run_behave(config, runner_class=None):
     try:
         reset_runtime()
         runner = RunnerPlugin(runner_class).make_runner(config)
-        print("USING RUNNER: {0}".format(make_scoped_class_name(runner)))
+        print("USING RUNNER: {0}".format(make_scoped_class_name(runner)),
+              file=sys.stderr)
         failed = runner.run()
     except ParserError as e:
         print("ParserError: %s" % e)

--- a/behave4cmd0/command_steps.py
+++ b/behave4cmd0/command_steps.py
@@ -191,6 +191,19 @@ def step_command_output_should_not_contain_text(ctx, text):
         textutil.assert_normtext_should_not_contain(actual_output, expected_text)
 
 
+@then('the command stdout should not contain "{text}"')
+def step_command_stdout_should_not_contain_text(ctx, text):
+    '''
+    EXAMPLE:
+        ...
+        then the command stdout should not contain "TEXT"
+    '''
+    expected_text = normalize_text_with_placeholders(ctx, text)
+    actual_output = ctx.command_result.stdout
+    with on_assert_failed_print_details(actual_output, expected_text):
+        textutil.assert_normtext_should_not_contain(actual_output, expected_text)
+
+
 @then('the command output should contain "{text}" {count:d} times')
 def step_command_output_should_contain_text_multiple_times(ctx, text, count):
     '''

--- a/issue.features/issue1319.feature
+++ b/issue.features/issue1319.feature
@@ -28,4 +28,4 @@ Feature: Issue #1319 -- USING RUNNER message should not go to stdout
       1 scenario passed, 0 failed, 0 skipped
       1 step passed, 0 failed, 0 skipped
       """
-    But the command output should not contain "USING RUNNER"
+    But the command stdout should not contain "USING RUNNER"

--- a/issue.features/issue1319.feature
+++ b/issue.features/issue1319.feature
@@ -1,0 +1,31 @@
+@issue
+Feature: Issue #1319 -- USING RUNNER message should not go to stdout
+
+  . DESCRIPTION:
+  .   The "USING RUNNER: ..." message was printed unconditionally to stdout,
+  .   interfering with custom formatters that write to stdout and whose output
+  .   is parsed by external tools. This message is diagnostic and should go
+  .   to stderr instead.
+  .
+  . SEE ALSO:
+  .   * https://github.com/behave/behave/issues/1319
+
+  Scenario: USING RUNNER is not on stdout
+    Given a new working directory
+    And a file named "features/steps/use_steplib_behave4cmd.py" with:
+      """
+      import behave4cmd0.passing_steps
+      """
+    And a file named "features/run_with_runner.feature" with:
+      """
+      Feature: Runner output
+        Scenario: S1
+          Given a step passes
+      """
+    When I run "behave features/run_with_runner.feature"
+    Then it should pass with:
+      """
+      1 scenario passed, 0 failed, 0 skipped
+      1 step passed, 0 failed, 0 skipped
+      """
+    But the command output should not contain "USING RUNNER"


### PR DESCRIPTION
## Summary

Fixes #1319.

The `USING RUNNER: ...` message was printed unconditionally to `stdout` in `behave/__main__.py`, interfering with custom formatters whose output is parsed by external tools. As a diagnostic message, it belongs on `stderr`.

## Changes

- **`behave/__main__.py`**: Changed `print("USING RUNNER: ...")` to use `file=sys.stderr`.
- **`issue.features/issue1319.feature`**: End-to-end regression test verifying `USING RUNNER` does not appear in stdout.
- **`CHANGES.rst`**: Changelog entry under FIXED.

## Notes

- The existing `issue.features/issue1284.feature` test still passes because `CommandResult.output` in `behave4cmd0` combines both `stdout` and `stderr`, so the `USING RUNNER` assertion there continues to work.
- This is the minimal fix. An alternative would be adding a `--no-runner-info` flag, but sending diagnostics to stderr is the standard Unix convention and requires no new configuration.