### PR TITLE
fix: scenario_autoretry does not reset runner.hook_failures (#1128)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ FIXED:
 * Include changes from ``behave v1.3.1`` (#1255, #1239)
 * issue #1028: use unittest.mock instead of mock (submitted by: pgajdos)
 * pull #1297: Context._pop(): Use internal config reference to avoid cleanup-errors if "context.config" is masked (provided by: wiebren)
+* issue #1128: scenario_autoretry now resets ``runner.hook_failures`` between retry attempts
 
 DOCUMENTATION:
 

--- a/behave/contrib/scenario_autoretry.py
+++ b/behave/contrib/scenario_autoretry.py
@@ -48,7 +48,16 @@ def patch_scenario_with_autoretry(scenario, max_attempts=3):
     :param max_attempts:    How many times the scenario can be run.
     """
     def scenario_run_with_retries(scenario_run, *args, **kwargs):
+        # -- HINT: Scenario.run(runner) => First positional arg is the runner.
+        runner = args[0]
+        # -- RECORD test-runner state to restore it on each retry attempt.
+        # OTHERWISE: A failed hook (before_scenario/after_scenario) on one
+        # attempt would leak its "runner.hook_failures" into later attempts
+        # and cause the test-run to fail even if a retry attempt passed.
+        hook_failures_on_start = runner.hook_failures
         for attempt in range(1, max_attempts+1):
+            # -- RESTORE test-runner state before each (retried) scenario run.
+            runner.hook_failures = hook_failures_on_start
             if not scenario_run(*args, **kwargs):
                 if attempt > 1:
                     message = "AUTO-RETRY SCENARIO PASSED (after {0} attempts)"

--- a/issue.features/issue1128.feature
+++ b/issue.features/issue1128.feature
@@ -1,0 +1,69 @@
+@issue
+@autoretry
+Feature: Issue #1128 -- scenario_autoretry does not reset runner.hook_failures
+
+  Ensure that "patch_scenario_with_autoretry()" restores the test-runner state
+  (the "runner.hook_failures" counter) between retry attempts.
+
+  . REGRESSION: The "scenario_autoretry" monkey-patch retried a failed scenario,
+  .   but did not reset "runner.hook_failures". If a "before_scenario" or
+  .   "after_scenario" hook failed on the first attempt and then passed on the
+  .   retry, the scenario was reported as PASSED, but behave still exited with
+  .   failure because "runner.hook_failures" remained non-zero.
+  .
+  . RELATED:
+  .  * features/runner.scenario_autoretry.feature
+  .  * behave/contrib/scenario_autoretry.py
+
+  Background:
+    Given a new working directory
+    And a file named "features/steps/reuse_steps.py" with:
+        """
+        import behave4cmd0.passing_steps
+        """
+    And a file named "features/environment.py" with:
+        """
+        from behave.contrib.scenario_autoretry import patch_scenario_with_autoretry
+
+        # -- FAULT-INJECTION: Fail the "before_scenario" hook on the first
+        # attempt only; it passes on the retry.
+        before_scenario_calls = 0
+
+        def before_feature(context, feature):
+            for scenario in feature.scenarios:
+                if "autoretry" in scenario.effective_tags:
+                    patch_scenario_with_autoretry(scenario, max_attempts=2)
+
+        def before_scenario(context, scenario):
+            global before_scenario_calls
+            before_scenario_calls += 1
+            if before_scenario_calls == 1:
+                raise RuntimeError("OOPS, before_scenario failed (first attempt)")
+        """
+    And a file named "features/unreliable_hook.feature" with:
+        """
+        @autoretry
+        Feature: Alice
+            Scenario: A1
+              Given a step passes
+        """
+    And a file named "behave.ini" with:
+        """
+        [behave]
+        show_timings = false
+        """
+
+  Scenario: Retry recovers from a hook failure and the test-run passes
+    When I run "behave -f plain features/unreliable_hook.feature"
+    Then it should pass with:
+        """
+        1 scenario passed, 0 failed, 0 skipped
+        """
+    And the command output should contain:
+        """
+        AUTO-RETRY SCENARIO (attempt 1)
+        """
+    But the command output should not contain:
+        """
+        AUTO-RETRY SCENARIO FAILED
+        """


### PR DESCRIPTION
## Summary

Fixes #1128.

`patch_scenario_with_autoretry()` retried a failed scenario but never reset the
test-runner's hook-failure state. When a `before_scenario` / `after_scenario`
hook failed on one attempt and the scenario then passed on a retry, the scenario
was correctly reported as **passed**, yet `behave` still exited with **failure**
because `runner.hook_failures` was left non-zero (the exit status is computed as
`... or self.hook_failures > 0` in `ModelRunner.run_model()`).

## Fix

Follows the solution sketch from @jenisys in the issue: record the test-runner
state (only `runner.hook_failures`) before the retry loop and restore it before
each attempt, so a hook failure from a previous attempt does not leak into a
later, passing one.

```python
runner = args[0]
hook_failures_on_start = runner.hook_failures
for attempt in range(1, max_attempts + 1):
    runner.hook_failures = hook_failures_on_start   # -- restore before each (retried) run
    ...
```

## Regression test

`issue.features/issue1128.feature` — a `before_scenario` hook fails on the first
attempt and passes on the retry. It asserts the run **passes** with
`1 scenario passed, 0 failed`.

- On `main` (before the fix): the inner run reports `1 scenario passed, 0 failed`
  but exits `1` (`Expected: <0> but: was <1>`) → the feature **fails**.
- With the fix: the run exits `0` → the feature **passes**.

## Verification

Run in a clean `python:3.12` container (`pip install -e ".[testing]"`):

- `bin/behave issue.features/issue1128.feature` — RED before, GREEN after.
- `bin/behave features/runner.scenario_autoretry.feature` — still passes (no regression).
- `pytest tests/` — `1639 passed, 3 skipped, 2 xfailed`.

`CHANGES.rst` updated.

---
_fwiw: drafted with AI assistance (Claude); reviewed and verified by me._